### PR TITLE
Allow broadcasting All and Between

### DIFF
--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -144,6 +144,13 @@ Between(x::AbstractString, y::AbstractString) = Between(Symbol(x), Symbol(y))
 Between(x::Union{Int, Symbol}, y::AbstractString) = Between(x, Symbol(y))
 Between(x::AbstractString, y::Union{Int, Symbol}) = Between(Symbol(x), y)
 
+struct BroadcastedBetween{T1 <: Union{Int, Symbol}, T2 <: Union{Int, Symbol}}
+    first::T1
+    last::T2
+end
+
+Base.Broadcast.broadcastable(x::Between) = Ref(BroadcastedBetween(x.first, x.last))
+
 """
     All(cols...)
 
@@ -168,6 +175,13 @@ struct Cols{T<:Tuple}
     cols::T
     Cols(args...) = new{typeof(args)}(args)
 end
+
+struct BroadcastedAll{T<:Tuple}
+    cols::T
+    BroadcastedAll(args...) = new{typeof(args)}(args)
+end
+
+Base.Broadcast.broadcastable(x::All) = Ref(BroadcastedAll(x.cols...))
 
 """
     unwrap(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,9 @@ end
         b = DataAPI.Between(x, y)
         @test b.first == (x isa Int ? x : Symbol(x))
         @test b.last == (y isa Int ? y : Symbol(y))
+
+        @test (b .=> sum) === (DataAPI.BroadcastedBetween(x, y) => sum)
+        @test (b .=> [sum, float]) == (Ref(DataAPI.BroadcastedBetween(x, y)) .=> [sum, float])
     end
 
     @test_throws MethodError DataAPI.Between(true, 1)
@@ -82,6 +85,11 @@ end
         @test a.cols[1] isa v
         @test a.cols[1].cols == ()
     end
+
+    @test (DataAPI.All() .=> sum) === (DataAPI.BroadcastedAll() => sum)
+    @test (DataAPI.All(:a) .=> sum) === (DataAPI.BroadcastedAll(:a) => sum)
+    @test (DataAPI.All((1,2,3), :b) .=> sum) === (DataAPI.BroadcastedAll((1,2,3), :b) => sum)
+    @test (DataAPI.All() .=> [sum, float]) == (Ref(DataAPI.BroadcastedAll()) .=> [sum, float])
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,8 +64,10 @@ end
         @test b.first == (x isa Int ? x : Symbol(x))
         @test b.last == (y isa Int ? y : Symbol(y))
 
-        @test (b .=> sum) === (DataAPI.BroadcastedBetween(x, y) => sum)
-        @test (b .=> [sum, float]) == (Ref(DataAPI.BroadcastedBetween(x, y)) .=> [sum, float])
+        @test (b .=> sum) ===
+            (DataAPI.BroadcastedSelector(DataAPI.Between(x, y)) => sum)
+        @test (b .=> [sum, float]) ==
+            (Ref(DataAPI.BroadcastedSelector(DataAPI.Between(x, y))) .=> [sum, float])
     end
 
     @test_throws MethodError DataAPI.Between(true, 1)
@@ -84,12 +86,16 @@ end
         @test length(a.cols) == 1
         @test a.cols[1] isa v
         @test a.cols[1].cols == ()
-    end
 
-    @test (DataAPI.All() .=> sum) === (DataAPI.BroadcastedAll() => sum)
-    @test (DataAPI.All(:a) .=> sum) === (DataAPI.BroadcastedAll(:a) => sum)
-    @test (DataAPI.All((1,2,3), :b) .=> sum) === (DataAPI.BroadcastedAll((1,2,3), :b) => sum)
-    @test (DataAPI.All() .=> [sum, float]) == (Ref(DataAPI.BroadcastedAll()) .=> [sum, float])
+        @test (v() .=> sum) ===
+            (DataAPI.BroadcastedSelector(v()) => sum)
+        @test (v(:a) .=> sum) ===
+            (DataAPI.BroadcastedSelector(v(:a)) => sum)
+        @test (v((1,2,3), :b) .=> sum) ===
+            (DataAPI.BroadcastedSelector(v((1,2,3), :b)) => sum)
+        @test (v() .=> [sum, float]) ==
+            (Ref(DataAPI.BroadcastedSelector(v())) .=> [sum, float])
+    end
 
 end
 


### PR DESCRIPTION
This would allow writing things like `by(df, All() .=> sum)` to compute the sum of each column (replacing `aggregate`), as a shorthand for `by(df, names(df) .=> sum)`. For  `Between` and other selectors we could add in the future, that pattern would be even more convenient. Basically, it's a kind of deferred broadcasting, given that the actual columns aren't known at the time `broadcast` is called.

I wonder whether this is the best implementation. It's hard to decide since I can't think of any other operator than `=>` that we might want to broadcast. The risk is that it will work for some cases that we don't necessarily want to allow, e.g. `identity.(DataAPI.All())` or `DataAPI.All() .== 1:3`. It fails for most operations, though, because `All` and `Between` don't define any methods.

Ref. https://github.com/JuliaData/DataFrames.jl/issues/1256#issuecomment-483011499.