### PR TITLE
Make levels docstring more precise

### DIFF
--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -85,6 +85,7 @@ function describe end
 Return a vector of unique values which occur or could occur in collection `x`,
 omitting `missing` even if present. Values are returned in the preferred order
 for the collection, with the result of [`sort`](@ref) as a default.
+If the collection is nod ordered then the order of levels is unspecified.
 
 Contrary to [`unique`](@ref), this function may return values which do not
 actually occur in the data, and does not preserve their order of appearance in `x`.

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -85,7 +85,7 @@ function describe end
 Return a vector of unique values which occur or could occur in collection `x`,
 omitting `missing` even if present. Values are returned in the preferred order
 for the collection, with the result of [`sort`](@ref) as a default.
-If the collection is nod ordered then the order of levels is unspecified.
+If the collection is not sortable then the order of levels is unspecified.
 
 Contrary to [`unique`](@ref), this function may return values which do not
 actually occur in the data, and does not preserve their order of appearance in `x`.


### PR DESCRIPTION
If `sort!` fails then (fortunately) no levels are lost, but it might reorder part of the vector before failing.