### PR TITLE
Fix levels on Julia 1.7

### DIFF
--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -95,7 +95,7 @@ function levels(x)
     u = unique(x)
     # unique returns its input with copying for ranges
     # (and possibly for other types guaranteed to hold unique values)
-    nmu = u === x ? filter(!ismissing, u) : filter!(!ismissing, u)
+    nmu = (u === x || Base.mightalias(u, x)) ? filter(!ismissing, u) : filter!(!ismissing, u)
     levs = convert(AbstractArray{T}, nmu)
     try
         sort!(levs)

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -92,7 +92,11 @@ actually occur in the data, and does not preserve their order of appearance in `
 """
 function levels(x)
     T = Base.nonmissingtype(eltype(x))
-    levs = convert(AbstractArray{T}, filter!(!ismissing, unique(x)))
+    u = unique(x)
+    # unique returns its input with copying for ranges
+    # (and possibly for other types guaranteed to hold unique values)
+    nmu = u === x ? filter(!ismissing, u) : filter!(!ismissing, u)
+    levs = convert(AbstractArray{T}, nmu)
     try
         sort!(levs)
     catch


### PR DESCRIPTION
`unique` now returns a range for range inputs, so we cannot update it in place.