### PR TITLE
Add invrefpool

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataAPI"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.4.1"
+version = "1.5.0"
 
 [compat]
 julia = "1"

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -70,6 +70,23 @@ function refpool end
 refpool(A::AbstractArray) = nothing
 
 """
+    invrefpool(A)
+
+Whenever available, return an indexable object `invpool` such that, given the *original*
+array `A` and a "value" `x`, `pool(A)[invpool(A)[x]]` is equal to `x`.
+Return `nothing` if such "ref value" is not available.
+
+By default, `refpool(A)` returns `nothing`.
+
+If `invrefpool(A)` is not `nothing`, then `pool(A)` also muts not be `nothing`.
+
+This generic function is owned by DataAPI.jl itself, which is the sole provider of the
+default definition.
+"""
+function invrefpool end
+invrefpool(A::AbstractArray) = nothing
+
+"""
     describe(io::IO, x)
 
 For an object `x`, print descriptive statistics to `io`.

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -74,7 +74,7 @@ refpool(A::AbstractArray) = nothing
 
 Whenever available, return an indexable object `invpool` such that, given the *original*
 array `A` and a "value" `x`, `pool(A)[invpool(A)[x]]` is equal to `x`.
-Return `nothing` if such "ref value" is not available.
+`invpool(A)[x]` returns `nothing` if such `x` is not available.
 
 By default, `refpool(A)` returns `nothing`.
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -72,12 +72,16 @@ refpool(A::AbstractArray) = nothing
 """
     invrefpool(A)
 
-Whenever available, return an indexable object such that given an array `A` for which `refpool(A)` is not `nothing` such that:
+Whenever available, return an indexable object such that given an array `A`
+for which `refpool(A)` is not `nothing`:
 
-* for any valid index `x` into `refpool(A)` the following holds `invrefpool(A)[refpool(A)[x]] === x`;
-* for any valid index `ix` into `invrefpool(A)` the following holds `refpool(A)[invrefpool(A)[ix]] === ix`.
+* for any valid index `x` into `refpool(A)`, `invrefpool(A)[refpool(A)[x]]` is equal to `x`
+  (according to `isequal`) and of the same type as `x`;
+* for any valid index `ix` into `invrefpool(A)` , `refpool(A)[invrefpool(A)[ix]]` is equal to `ix`
+  (according to `isequal`) and of the same type as `ix`.
 
-Additionally it is requred that `haskey` is defined for `invrefpool(A)` allowing to check if `ix` is a valid index into it.
+Additionally it is required that `haskey` is defined for `invrefpool(A)`,
+allowing to check if `ix` is a valid index into it.
 
 By default, `refpool(A)` returns `nothing`.
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -72,13 +72,14 @@ refpool(A::AbstractArray) = nothing
 """
     invrefpool(A)
 
-Whenever available, return an indexable object `invpool` such that, given the *original*
-array `A` and a "value" `x`, `pool(A)[invpool(A)[x]]` is equal to `x`.
-`invpool(A)[x]` returns `nothing` if such `x` is not available.
+Whenever available, return an indexable object such that, given an array `A` and
+a "value" `x` taken from `A`, `refpool(A)[invrefpool(A)[x]]` is equal to `x`
+(according to `isequal`) and of the same type as `x`.
+`invrefpool(A)[x]` returns `nothing` if such `x` is not available.
 
 By default, `refpool(A)` returns `nothing`.
 
-If `invrefpool(A)` is not `nothing`, then `pool(A)` also muts not be `nothing`.
+If `invrefpool(A)` is not `nothing`, then `pool(A)` also must not be `nothing`.
 
 This generic function is owned by DataAPI.jl itself, which is the sole provider of the
 default definition.

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -83,7 +83,7 @@ for which `refpool(A)` is not `nothing`:
 Additionally it is required that `haskey` is defined for `invrefpool(A)`,
 allowing to check if `ix` is a valid index into it.
 
-By default, `refpool(A)` returns `nothing`.
+By default, `invrefpool(A)` returns `nothing`.
 
 If `invrefpool(A)` is not `nothing`, then `refpool(A)` also must not be `nothing`.
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -72,14 +72,16 @@ refpool(A::AbstractArray) = nothing
 """
     invrefpool(A)
 
-Whenever available, return an indexable object such that, given an array `A` and
-a "value" `x` taken from `A`, `refpool(A)[invrefpool(A)[x]]` is equal to `x`
-(according to `isequal`) and of the same type as `x`.
-`invrefpool(A)[x]` returns `nothing` if such `x` is not available.
+Whenever available, return an indexable object such that given an array `A` for which `refpool(A)` is not `nothing` such that:
+
+* for any valid index `x` into `refpool(A)` the following holds `invrefpool(A)[refpool(A)[x]] === x`;
+* for any valid index `ix` into `invrefpool(A)` the following holds `refpool(A)[invrefpool(A)[ix]] === ix`.
+
+Additionally it is requred that `haskey` is defined for `invrefpool(A)` allowing to check if `ix` is a valid index into it.
 
 By default, `refpool(A)` returns `nothing`.
 
-If `invrefpool(A)` is not `nothing`, then `pool(A)` also must not be `nothing`.
+If `invrefpool(A)` is not `nothing`, then `refpool(A)` also must not be `nothing`.
 
 This generic function is owned by DataAPI.jl itself, which is the sole provider of the
 default definition.


### PR DESCRIPTION
Having a generic access to `invrefpool` is needed in https://github.com/JuliaData/DataFrames.jl/pull/2612.

Consider a short table and a long table joined on some column. In order to be fast we need to map values from short table key to ref values of long table key. This allows two things for `innerjoin`:
1. we immediately can drop values from short table not present in long table.
2. later we can do join on integer columns which is way faster than joining on e.g. string column.

Also since we do mapping of short table this operation should be fast.

In particular if short table defines `refarray` it is particularly fast, as we only need to map the reference values.

For CategoricalArrays.jl and PooledArrays.jl `invrefpool` is simply `get` on the inverted pool `Dict` with `nothing` as a sentinel.

I am not sure what would have to be defined in Arrow.jl.