### PR TITLE
Add DataAPI.unwrap with default definition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataAPI"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.5.1"
+version = "1.6.0"
 
 [compat]
 julia = "1"

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -169,4 +169,18 @@ struct Cols{T<:Tuple}
     Cols(args...) = new{typeof(args)}(args)
 end
 
+"""
+    unwrap(x)
+
+For a given scalar argument `x`, potentially "unwrap" it to return the base wrapped value.
+Useful as a generic API for wrapper types when the original value is needed.
+
+The default definition just returns `x` itself, i.e. no unwrapping is performned.
+
+This generic function is owned by DataAPI.jl itself, which is the sole provider of the
+default definition.
+"""
+function unwrap end
+unwrap(x) = x
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,4 +85,9 @@ end
 
 end
 
+@testset "unwrap" begin
+    @test DataAPI.unwrap(1) === 1
+    @test DataAPI.unwrap(missing) === missing
+end
+
 end # @testset "DataAPI"


### PR DESCRIPTION
As discussed in
https://github.com/JuliaData/CategoricalArrays.jl/issues/142.