### PR TITLE
Add `join` family without default definition

### DIFF
--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -183,128 +183,16 @@ default definition.
 function unwrap end
 unwrap(x) = x
 
-const _joindoc = """
-The implementation specific arguments, like the join key or equality rule,
-can be designed as the additional keyword arguments.
-"""
-
-"""
-    innerjoin(x, y)
-
-Perform a database-style inner join of two tabular objects and return a tabular
-object containing the result.
-
-$_joindoc
-
-See also: [`outerjoin`](@ref),
-          [`leftjoin`](@ref),
-          [`rightjoin`](@ref),
-          [`semijoin`](@ref),
-          [`antijoin`](@ref),
-          [`crossjoin`](@ref).
-"""
+# The database-style join methods for tabular data type.
+# The common interface is `*join(x, y; ...)` and use the keyword arguments
+# for the join criteria.
+# See the design of DataFrames.jl also.
 function innerjoin end
-
-"""
-    outerjoin(x, y)
-
-Perform a database-style outer join of two tabular objects and return a tabular
-object containing the result.
-
-$_joindoc
-
-See also: [`innerjoin`](@ref),
-          [`leftjoin`](@ref),
-          [`rightjoin`](@ref),
-          [`semijoin`](@ref),
-          [`antijoin`](@ref),
-          [`crossjoin`](@ref).
-"""
 function outerjoin end
-
-"""
-    rightjoin(x, y)
-
-Perform a database-style right join on two tabular objects and return a tabular
-object containing the result.
-
-$_joindoc
-
-See also: [`innerjoin`](@ref),
-          [`outerjoin`](@ref),
-          [`leftjoin`](@ref),
-          [`semijoin`](@ref),
-          [`antijoin`](@ref),
-          [`crossjoin`](@ref).
-"""
 function rightjoin end
-
-"""
-    leftjoin(x, y)
-
-Perform a database-style left join of two tabular objects and return a tabular
-object containing the result.
-
-$_joindoc
-
-See also: [`innerjoin`](@ref),
-          [`outerjoin`](@ref),
-          [`rightjoin`](@ref),
-          [`semijoin`](@ref),
-          [`antijoin`](@ref),
-          [`crossjoin`](@ref).
-"""
 function leftjoin end
-
-"""
-    semijoin(x, y)
-
-Perform a database-style semi join of two tabular objects and return a tabular
-object containing the result.
-
-$_joindoc
-
-See also: [`innerjoin`](@ref),
-          [`outerjoin`](@ref),
-          [`leftjoin`](@ref),
-          [`rightjoin`](@ref),
-          [`antijoin`](@ref),
-          [`crossjoin`](@ref).
-"""
 function semijoin end
-
-"""
-    antijoin(x, y)
-
-Perform a database-style anti join of two tabular objects and return a tabular
-object containing the result.
-
-$_joindoc
-
-See also: [`innerjoin`](@ref),
-          [`outerjoin`](@ref),
-          [`leftjoin`](@ref),
-          [`rightjoin`](@ref),
-          [`semijoin`](@ref),
-          [`crossjoin`](@ref).
-"""
 function antijoin end
-
-"""
-    crossjoin(x, y)
-
-Perform a database-style cross join of two tabular objects and return a tabular
-object containing the result.
-
-$_joindoc
-
-See also: [`innerjoin`](@ref),
-          [`outerjoin`](@ref),
-          [`leftjoin`](@ref),
-          [`rightjoin`](@ref),
-          [`semijoin`](@ref),
-          [`antijoin`](@ref).
-"""
 function crossjoin end
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -183,4 +183,102 @@ default definition.
 function unwrap end
 unwrap(x) = x
 
+"""
+    innerjoin(x, y, zs...)
+
+Perform an inner join of two or more objects.
+
+See also: [`outerjoin`](@ref),
+          [`leftjoin`](@ref),
+          [`rightjoin`](@ref),
+          [`semijoin`](@ref),
+          [`antijoin`](@ref),
+          [`crossjoin`](@ref).
+"""
+function innerjoin end
+
+"""
+    outerjoin(x, y, zs...)
+
+Perform an outer join of two or more objects.
+
+See also: [`innerjoin`](@ref),
+          [`leftjoin`](@ref),
+          [`rightjoin`](@ref),
+          [`semijoin`](@ref),
+          [`antijoin`](@ref),
+          [`crossjoin`](@ref).
+"""
+function outerjoin end
+
+"""
+    rightjoin(x, y)
+
+Perform a right join on two objects.
+
+See also: [`innerjoin`](@ref),
+          [`outerjoin`](@ref),
+          [`leftjoin`](@ref),
+          [`semijoin`](@ref),
+          [`antijoin`](@ref),
+          [`crossjoin`](@ref).
+"""
+function rightjoin end
+
+"""
+    leftjoin(x, y)
+
+Perform a left join of two objects.
+
+See also: [`innerjoin`](@ref),
+          [`outerjoin`](@ref),
+          [`rightjoin`](@ref),
+          [`semijoin`](@ref),
+          [`antijoin`](@ref),
+          [`crossjoin`](@ref).
+"""
+function leftjoin end
+
+"""
+    semijoin(x, y)
+
+Perform a semi join of two objects.
+
+See also: [`innerjoin`](@ref),
+          [`outerjoin`](@ref),
+          [`leftjoin`](@ref),
+          [`rightjoin`](@ref),
+          [`antijoin`](@ref),
+          [`crossjoin`](@ref).
+"""
+function semijoin end
+
+"""
+    antijoin(x, y)
+
+Perform an anti join of two objects.
+
+See also: [`innerjoin`](@ref),
+          [`outerjoin`](@ref),
+          [`leftjoin`](@ref),
+          [`rightjoin`](@ref),
+          [`semijoin`](@ref),
+          [`crossjoin`](@ref).
+"""
+function antijoin end
+
+"""
+    crossjoin(x, y, zs...)
+
+Perform a cross join of two or more objects.
+
+See also: [`innerjoin`](@ref),
+          [`outerjoin`](@ref),
+          [`leftjoin`](@ref),
+          [`rightjoin`](@ref),
+          [`semijoin`](@ref),
+          [`antijoin`](@ref).
+"""
+function crossjoin end
+
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -184,7 +184,7 @@ function unwrap end
 unwrap(x) = x
 
 """
-    innerjoin(x, y, zs...)
+    innerjoin(x, y)
 
 Perform an inner join of two or more objects.
 
@@ -198,7 +198,7 @@ See also: [`outerjoin`](@ref),
 function innerjoin end
 
 """
-    outerjoin(x, y, zs...)
+    outerjoin(x, y)
 
 Perform an outer join of two or more objects.
 
@@ -268,7 +268,7 @@ See also: [`innerjoin`](@ref),
 function antijoin end
 
 """
-    crossjoin(x, y, zs...)
+    crossjoin(x, y)
 
 Perform a cross join of two or more objects.
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -183,10 +183,18 @@ default definition.
 function unwrap end
 unwrap(x) = x
 
+const _joindoc = """
+The implementation specific arguments, like the join key or equality rule,
+can be designed as the additional keyword arguments.
+"""
+
 """
     innerjoin(x, y)
 
-Perform an inner join of two or more objects.
+Perform a database-style inner join of two tabular objects and return a tabular
+object containing the result.
+
+$_joindoc
 
 See also: [`outerjoin`](@ref),
           [`leftjoin`](@ref),
@@ -200,7 +208,10 @@ function innerjoin end
 """
     outerjoin(x, y)
 
-Perform an outer join of two or more objects.
+Perform a database-style outer join of two tabular objects and return a tabular
+object containing the result.
+
+$_joindoc
 
 See also: [`innerjoin`](@ref),
           [`leftjoin`](@ref),
@@ -214,7 +225,10 @@ function outerjoin end
 """
     rightjoin(x, y)
 
-Perform a right join on two objects.
+Perform a database-style right join on two tabular objects and return a tabular
+object containing the result.
+
+$_joindoc
 
 See also: [`innerjoin`](@ref),
           [`outerjoin`](@ref),
@@ -228,7 +242,10 @@ function rightjoin end
 """
     leftjoin(x, y)
 
-Perform a left join of two objects.
+Perform a database-style left join of two tabular objects and return a tabular
+object containing the result.
+
+$_joindoc
 
 See also: [`innerjoin`](@ref),
           [`outerjoin`](@ref),
@@ -242,7 +259,10 @@ function leftjoin end
 """
     semijoin(x, y)
 
-Perform a semi join of two objects.
+Perform a database-style semi join of two tabular objects and return a tabular
+object containing the result.
+
+$_joindoc
 
 See also: [`innerjoin`](@ref),
           [`outerjoin`](@ref),
@@ -256,7 +276,10 @@ function semijoin end
 """
     antijoin(x, y)
 
-Perform an anti join of two objects.
+Perform a database-style anti join of two tabular objects and return a tabular
+object containing the result.
+
+$_joindoc
 
 See also: [`innerjoin`](@ref),
           [`outerjoin`](@ref),
@@ -270,7 +293,10 @@ function antijoin end
 """
     crossjoin(x, y)
 
-Perform a cross join of two or more objects.
+Perform a database-style cross join of two tabular objects and return a tabular
+object containing the result.
+
+$_joindoc
 
 See also: [`innerjoin`](@ref),
           [`outerjoin`](@ref),


### PR DESCRIPTION
close https://github.com/JuliaData/Tables.jl/issues/238

Well, I think the default definition isn't trivial to implement, so I just setup the interface functions.
I don't restrict the parameter of join key, which is the kwarg `on` in DataFrames.jl, since the join key is optional in some cases of time series join. 