### PR TITLE
Add `skipmissing` argument to `levels`

### DIFF
--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -105,6 +105,9 @@ definition.
 """
 function describe end
 
+# Sentinel type needed to make `levels` inferrable
+struct _Default end
+
 """
     levels(x; skipmissing=true)
 
@@ -118,8 +121,9 @@ If the collection is not sortable then the order of levels is unspecified.
 Contrary to [`unique`](@ref), this function may return values which do not
 actually occur in the data, and does not preserve their order of appearance in `x`.
 """
-@inline levels(x; skipmissing::Bool=true) =
-    skipmissing ? _levels_skipmissing(x) : _levels_missing(x)
+@inline levels(x; skipmissing::Union{Bool, _Default}=_Default()) =
+    skipmissing isa _Default || skipmissing ?
+        _levels_skipmissing(x) : _levels_missing(x)
 
 # The `which` check is here for backward compatibility:
 # if a type implements a custom `levels` method but does not support

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Test, DataAPI
 
+const ≅ = isequal
+
 @testset "DataAPI" begin
 
 @testset "defaultarray" begin
@@ -29,15 +31,15 @@ end
 
 @testset "levels" begin
 
-    @test DataAPI.levels(1:1) ==
-        DataAPI.levels([1]) ==
-        DataAPI.levels([1, missing]) ==
-        DataAPI.levels([missing, 1]) ==
+    @test @inferred(DataAPI.levels(1:1)) ==
+        @inferred(DataAPI.levels([1])) ==
+        @inferred(DataAPI.levels([1, missing])) ==
+        @inferred(DataAPI.levels([missing, 1])) ==
         [1]
-    @test DataAPI.levels(2:-1:1) ==
-        DataAPI.levels([2, 1]) ==
-        DataAPI.levels(Any[2, 1]) ==
-        DataAPI.levels([2, missing, 1]) ==
+    @test @inferred(DataAPI.levels(2:-1:1)) ==
+        @inferred(DataAPI.levels([2, 1])) ==
+        @inferred(DataAPI.levels(Any[2, 1])) ==
+        @inferred(DataAPI.levels([2, missing, 1])) ==
         [1, 2]
     @test DataAPI.levels([missing, "a", "c", missing, "b"]) == ["a", "b", "c"]
     @test DataAPI.levels([Complex(0, 1), Complex(1, 0), missing]) ==
@@ -55,6 +57,40 @@ end
     @test isempty(DataAPI.levels([missing]))
     @test isempty(DataAPI.levels([]))
 
+    levels_skipmissing(x) = DataAPI.levels(x, skipmissing=false)
+    @test @inferred(levels_skipmissing(1:1)) ≅
+        @inferred(levels_skipmissing([1])) ≅
+        [1]
+    @test @inferred(levels_skipmissing([1, missing])) ≅
+        @inferred(levels_skipmissing([missing, 1])) ≅
+        [1, missing]
+    @test @inferred(levels_skipmissing(2:-1:1)) ≅
+        @inferred(levels_skipmissing([2, 1])) ≅
+        [1, 2]
+    @test @inferred(levels_skipmissing(Any[2, 1])) ≅
+        [1, 2]
+    @test DataAPI.levels([2, missing, 1], skipmissing=false) ≅
+        [1, 2, missing]
+    @test DataAPI.levels([missing, "a", "c", missing, "b"], skipmissing=false) ≅
+        ["a", "b", "c", missing]
+    @test DataAPI.levels([Complex(0, 1), Complex(1, 0), missing], skipmissing=false) ≅
+        [Complex(0, 1), Complex(1, 0), missing]
+    @test typeof(DataAPI.levels([1], skipmissing=false)) === Vector{Int}
+    @test typeof(DataAPI.levels([1, missing], skipmissing=false)) ===
+        Vector{Union{Int, Missing}}
+    @test typeof(DataAPI.levels(["a"], skipmissing=false)) === Vector{String}
+    @test typeof(DataAPI.levels(["a", missing], skipmissing=false)) ===
+        Vector{Union{String, Missing}}
+    @test typeof(DataAPI.levels(Real[1], skipmissing=false)) === Vector{Real}
+    @test typeof(DataAPI.levels(Union{Real,Missing}[1, missing], skipmissing=false)) ===
+        Vector{Union{Real, Missing}}
+    @test typeof(DataAPI.levels(trues(1), skipmissing=false)) === Vector{Bool}
+    @test DataAPI.levels([missing], skipmissing=false) ≅ [missing]
+    @test DataAPI.levels([missing], skipmissing=false) isa Vector{Missing}
+    @test typeof(DataAPI.levels(Union{Int,Missing}[missing], skipmissing=false)) ===
+        Vector{Union{Int,Missing}}
+    @test isempty(DataAPI.levels([], skipmissing=false))
+    @test typeof(DataAPI.levels(Int[], skipmissing=false)) === Vector{Int}
 end
 
 @testset "Between" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,9 +61,15 @@ end
     @test @inferred(levels_skipmissing(1:1)) ≅
         @inferred(levels_skipmissing([1])) ≅
         [1]
-    @test @inferred(levels_skipmissing([1, missing])) ≅
-        @inferred(levels_skipmissing([missing, 1])) ≅
-        [1, missing]
+    if VERSION >= v"1.6.0"
+        @test @inferred(levels_skipmissing([1, missing])) ≅
+            @inferred(levels_skipmissing([missing, 1])) ≅
+            [1, missing]
+    else
+        @test levels_skipmissing([1, missing]) ≅
+            levels_skipmissing([missing, 1]) ≅
+            [1, missing]
+    end
     @test @inferred(levels_skipmissing(2:-1:1)) ≅
         @inferred(levels_skipmissing([2, 1])) ≅
         [1, 2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,12 @@ end
 
 end
 
+struct TestArray <: AbstractVector{Union{Int, Missing}}
+end
+Base.size(x::TestArray) = (2,)
+Base.getindex(x::TestArray, i) = (checkbounds(x, i); i == 1 ? missing : i-1)
+DataAPI.levels(::TestArray) = [2, 1]
+
 @testset "levels" begin
 
     @test @inferred(DataAPI.levels(1:1)) ==
@@ -57,23 +63,23 @@ end
     @test isempty(DataAPI.levels([missing]))
     @test isempty(DataAPI.levels([]))
 
-    levels_skipmissing(x) = DataAPI.levels(x, skipmissing=false)
-    @test @inferred(levels_skipmissing(1:1)) ≅
-        @inferred(levels_skipmissing([1])) ≅
+    levels_missing(x) = DataAPI.levels(x, skipmissing=false)
+    @test @inferred(levels_missing(1:1)) ≅
+        @inferred(levels_missing([1])) ≅
         [1]
     if VERSION >= v"1.6.0"
-        @test @inferred(levels_skipmissing([1, missing])) ≅
-            @inferred(levels_skipmissing([missing, 1])) ≅
+        @test @inferred(levels_missing([1, missing])) ≅
+            @inferred(levels_missing([missing, 1])) ≅
             [1, missing]
     else
-        @test levels_skipmissing([1, missing]) ≅
-            levels_skipmissing([missing, 1]) ≅
+        @test levels_missing([1, missing]) ≅
+            levels_missing([missing, 1]) ≅
             [1, missing]
     end
-    @test @inferred(levels_skipmissing(2:-1:1)) ≅
-        @inferred(levels_skipmissing([2, 1])) ≅
+    @test @inferred(levels_missing(2:-1:1)) ≅
+        @inferred(levels_missing([2, 1])) ≅
         [1, 2]
-    @test @inferred(levels_skipmissing(Any[2, 1])) ≅
+    @test @inferred(levels_missing(Any[2, 1])) ≅
         [1, 2]
     @test DataAPI.levels([2, missing, 1], skipmissing=false) ≅
         [1, 2, missing]
@@ -97,6 +103,10 @@ end
         Vector{Union{Int,Missing}}
     @test isempty(DataAPI.levels([], skipmissing=false))
     @test typeof(DataAPI.levels(Int[], skipmissing=false)) === Vector{Int}
+
+    @test DataAPI.levels(TestArray()) ==
+        DataAPI.levels(TestArray(), skipmissing=true) == [2, 1]
+    @test DataAPI.levels(TestArray(), skipmissing=false) ≅ [2, 1, missing]
 end
 
 @testset "Between" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,13 @@ using Test, DataAPI
 
 const ≅ = isequal
 
+# For `levels` tests
+struct TestArray <: AbstractVector{Union{Int, Missing}}
+end
+Base.size(x::TestArray) = (2,)
+Base.getindex(x::TestArray, i) = (checkbounds(x, i); i == 1 ? missing : i-1)
+DataAPI.levels(::TestArray) = [2, 1]
+
 @testset "DataAPI" begin
 
 @testset "defaultarray" begin
@@ -28,12 +35,6 @@ end
     @test DataAPI.refvalue(A, R[1]) === R[1]
 
 end
-
-struct TestArray <: AbstractVector{Union{Int, Missing}}
-end
-Base.size(x::TestArray) = (2,)
-Base.getindex(x::TestArray, i) = (checkbounds(x, i); i == 1 ? missing : i-1)
-DataAPI.levels(::TestArray) = [2, 1]
 
 @testset "levels" begin
 
@@ -104,6 +105,9 @@ DataAPI.levels(::TestArray) = [2, 1]
     @test isempty(DataAPI.levels([], skipmissing=false))
     @test typeof(DataAPI.levels(Int[], skipmissing=false)) === Vector{Int}
 
+    # Backward compatibility test:
+    # check that an array type which implements a `levels` method
+    # which does not accept keyword arguments works thanks to fallbacks
     @test DataAPI.levels(TestArray()) ==
         DataAPI.levels(TestArray(), skipmissing=true) == [2, 1]
     @test DataAPI.levels(TestArray(), skipmissing=false) ≅ [2, 1, missing]


### PR DESCRIPTION
Currently if one wants to get levels in their appropriate order, but add `missing` if present, the only solution is to do something like `union(levels(x), unique(x))`, which is inefficient.
Support `skipmissing=false` to allow doing this in a single pass over the data.

Use `@inline` to ensure that the return type can be inferred when the value of `skipmissing` is known statically. Also fix a type instability which existed for ranges.

Of course this new feature won't work for custom types which override this method (like `CategoricalArray`) until packages implement it. Unfortunately there's no way for packages which would like to rely on it (like DataFrames) to require an appropriate version.

There will also be a decision to make in CategoricalArrays as to whether `missing` should be returned only when present in the data (like the method defined here) or all the time as long as the eltype allows for it (like for other levels, which is more efficient).

Fixes https://github.com/JuliaData/DataAPI.jl/issues/44.