### PR TITLE
add `metadata`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataAPI"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.10.0"
+version = "1.11.0"
 
 [compat]
 julia = "1"

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -331,12 +331,22 @@ Return `true` if column `column` of Tables.jl table `table` has non-empty metada
 and return `false` if metadata is empty.
 Return `nothing` if metadata is not supported for `column`.
 
-
 `column` should be any accepted column identifier by `table`, but at least `Symbol` must be supported.
 
 If `hascolmetadata` returns `Bool` then it is guaranteed that call to
 `colmetatada(table, columns)` will not throw an error.
 """
 hascolmetadata(::Any, ::Any) = nothing
+
+"""
+    hascolmetadata(table)
+
+Return `true` if there is exists at least one column `column` of Tables.jl table
+`table` for which `hascolmetadata(table, column)` returns `true`; otherwise
+return `false`.
+
+Return `nothing` if metadata is not supported.
+"""
+hascolmetadata(::Any) = nothing
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -338,6 +338,19 @@ metadata!(::T, ::AbstractString, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
 
 """
+    deletemetadata!(x, [key::AbstractString])
+
+Delete metadata for object `x` for key `key` and return `x`
+(if metadata for `key` is not present do not perform any action).
+If `key` is not passed delete all metadata for object `x`.
+If `x` does not support metadata deletion throw `ArgumentError`.
+"""
+deletemetadata!(::T, ::AbstractString) where {T} =
+    throw(ArgumentError("Objects of type $T do not support metadata deletion"))
+deletemetadata!(::T) where {T} =
+    throw(ArgumentError("Objects of type $T do not support metadata deletion"))
+
+"""
     colmetadata(x, col, key::AbstractString; style::Bool=false)
 
 Return metadata value associated with table `x` for column `col` and key `key`.
@@ -383,7 +396,7 @@ colmetadatakeys(::Any) = ()
     colmetadata!(x, col, key::AbstractString, value; style)
 
 Set metadata for table `x` for column `col` for key `key` to have value `value`
-and style `style`.
+and style `style` and return `x`.
 If `x` does not support setting metadata for column `col` throw `ArgumentError`.
 
 $COL_INFO
@@ -394,5 +407,25 @@ colmetadata!(::T, ::Int, ::AbstractString, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
 colmetadata!(::T, ::Symbol, ::AbstractString, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
+
+"""
+    deletecolmetadata!(x, [col], [key::AbstractString])
+
+Delete metadata for table `x` for column `col` for key `key` and return `x`
+(if metadata for `key` is not present do not perform any action).
+If `key` is not passed delete all metadata for table `x` for column `col`.
+If only `x` is passed delete all column level metadata for table `x`.
+If `x` does not support metadata deletion for column `col` throw `ArgumentError`.
+"""
+deletecolmetadata!(::T, :Symbol, ::AbstractString) where {T} =
+    throw(ArgumentError("Objects of type $T do not support metadata deletion"))
+deletecolmetadata!(::T, :Int, ::AbstractString) where {T} =
+    throw(ArgumentError("Objects of type $T do not support metadata deletion"))
+deletecolmetadata!(::T, :Symbol) where {T} =
+    throw(ArgumentError("Objects of type $T do not support metadata deletion"))
+deletecolmetadata!(::T, :Int) where {T} =
+    throw(ArgumentError("Objects of type $T do not support metadata deletion"))
+deletecolmetadata!(::T) where {T} =
+    throw(ArgumentError("Objects of type $T do not support metadata deletion"))
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -419,11 +419,11 @@ If `x` does not support metadata deletion for column `col` throw `ArgumentError`
 """
 deletecolmetadata!(::T, ::Symbol, ::AbstractString) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
-deletecolmetadata!(::T, :Int, ::AbstractString) where {T} =
+deletecolmetadata!(::T, ::Int, ::AbstractString) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
 deletecolmetadata!(::T, ::Symbol) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
-deletecolmetadata!(::T, :Int) where {T} =
+deletecolmetadata!(::T, ::Int) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
 deletecolmetadata!(::T) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -391,8 +391,8 @@ preferred behavior if it is possible) or returns `()` (this duality is allowed
 as some Tables.jl tables do not have a schema).
 
 If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
-pairs for all columns that have metadata. If `x` does not support column
-metadata return `()`.
+pairs for all columns that have metadata, where `col` are `Symbol`.
+If `x` does not support column metadata return `()`.
 """
 colmetadatakeys(::Any, ::Int) = ()
 colmetadatakeys(::Any, ::Symbol) = ()

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -332,7 +332,7 @@ If `x` does not support setting metadata throw `ArgumentError`.
 
 $STYLE_INFO
 """
-metadata!(::T, ::Any; style) where {T} =
+metadata!(::T, ::Any, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
 
 """
@@ -380,7 +380,7 @@ If `x` does not support setting metadata for column `col` throw `ArgumentError`.
 
 $STYLE_INFO
 """
-colmetadata!(::T, ::Any, ::Any; style) where {T} =
+colmetadata!(::T, ::Any, ::Any, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -367,7 +367,7 @@ col, key)` returns a metadata value. If `x` does not support metadata for column
 
 `col` must have a type that is supported by table `x` for column indexing.
 Following the Tables.jl contract `Symbol` and `Int` are always allowed. Passing
-`col` that is not a column of `x` can either throws an error (this is a
+`col` that is not a column of `x` either throws an error (this is a
 preferred behavior if it is possible) or returns `()` (this duality is allowed
 as some Tables.jl tables do not have a schema).
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -287,4 +287,11 @@ using a `sink` function to materialize the table.
 """
 function allcombinations end
 
+"""
+    getmetadata(x, ...)
+
+Return metadata associated with object `x` or `nothing` if it doest not support metadata.
+"""
+getmetadata(::Any) = nothing
+
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -288,34 +288,67 @@ using a `sink` function to materialize the table.
 function allcombinations end
 
 """
-    metadata(x, [key])
+    metadata(x)
 
 Return metadata associated with object `x` as an `AbstractDict{String}` object
 (or an object implementing the same interface).
-
-If the optional `key` argument is passed, return metadata
-associated with the indicated key (this feature can be used, for example,
-to return metadata attached to a given column in a Tables.jl table).
 
 Note that some systems, like Arrow.jl, might assume that metadata values are
 also `String`.
 """
 metadata(::T) where {T} =
     throw(ArgumentError("Metadata is currently not supported for values of type $T"))
-metadata(::T, ::Any) where {T} =
+
+"""
+    colmetadata(table, column)
+
+Return metadata associated with column `column` of Tables.jl table `table` as an
+`AbstractDict{String}` object (or an object implementing the same interface).
+
+Note that some systems, like Arrow.jl, might assume that metadata values are
+also `String`.
+"""
+colmetadata(::T, ::Any) where {T} =
     throw(ArgumentError("Key metadata is currently not supported for values of type $T"))
 
 """
-    hasmetadata(x, [key])
+    colmetadata(table)
+
+Return metadata associated with columns of Tables.jl table `table` as an
+`AbstractDict{<:Any, <:AbstractString{String}}` object (or an object implementing
+the same interface).
+
+The returned dictionary must contain columns `column` for which
+`hascolmetadata(table, column)` returns `true` and a value associated to such
+key must be `colmetadata(table, column)`.
+"""
+colmetadata(::T, ::Any) where {T} =
+    throw(ArgumentError("Key metadata is currently not supported for values of type $T"))
+
+"""
+    hasmetadata(x)
 
 Return `true` if `x` has non-empty metadata, and return `false` if metadata is empty.
 Return `nothing` if `x` does not support metadata.
-
-If the optional `key` argument is passed, return information if metadata
-is associated with `key` (this feature can be used, for example,
-to query about metadata attached to a given column in a Tables.jl table).
 """
 hasmetadata(::Any) = nothing
-hasmetadata(::Any, ::Any) = nothing
+
+"""
+    hascolmetadata(table, column)
+
+Return `true` if column `column` of Tables.jl table `table` has non-empty metadata,
+and return `false` if metadata is empty.
+Return `nothing` if metadata is not supported.
+"""
+hascolmetadata(::Any, ::Any) = nothing
+
+"""
+    hascolmetadata(table)
+
+Return `true` if at least one column of of Tables.jl table `table` has non-empty
+metadata, and return `false` if metadata is empty for all columns.
+Return `nothing` if metadata is not supported.
+"""
+hascolmetadata(::Any) = nothing
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -311,8 +311,8 @@ metadata(::T, ::Any) where {T} =
 Return `true` if `x` has non-empty metadata, and return `false` if metadata is empty.
 Return `nothing` if `x` does not support metadata.
 
-If the optional `key` argument is passed, return information about whether
-metadata is associated with the indicated key (this feature can be used, for example,
+If the optional `key` argument is passed, return information if metadata
+is associated with `key` (this feature can be used, for example,
 to query about metadata attached to a given column in a Tables.jl table).
 """
 hasmetadata(::Any) = nothing

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -288,13 +288,33 @@ using a `sink` function to materialize the table.
 function allcombinations end
 
 """
-    metadata(x)
+    metadata(x, [column])
 
 Return metadata associated with object `x` as an `AbstractDict{String}` object
-(or an object implementing the same interface), or `nothing` if `x` does not support metadata.
+(or an object implementing the same interface).
+
+Optionally for Tables.jl tables a `columns` argument can be passed, in which case
+return metadata associated with the indicated column.
 
 Note that some systems, like Arrow.jl, might assume that metadata values are also `String`.
 """
-metadata(::Any) = nothing
+metadata(::T) where {T} = throw(ArgumentError("Metadata is currently not " *
+                                              "supported for values of type $T"))
+metadata(::T, ::Any) where {T} = throw(ArgumentError("Column metadata is currently not " *
+                                                     "supported for values of type $T"))
+
+"""
+    hasmetadata(x, [column])
+
+Return `true` if `x` has non-empty metadata, and return `false` if metadata is empty.
+Return `nothing` if `x` does not support metadata.
+
+Optionally for Tables.jl tables a `columns` argument can be passed, in which case
+return the same information about metadata associated with the indicated column.
+
+Note that some systems, like Arrow.jl, might assume that metadata values are also `String`.
+"""
+hasmetadata(::Any) = nothing
+hasmetadata(::Any, ::Any) = nothing
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -379,7 +379,12 @@ If `col` is passed return an iterator of metadata keys for which
 `metadata(x, col, key)` returns a metadata value.
 If `x` does not support metadata for column `col` return `()`.
 
-$COL_INFO
+`col` must be a type that is supported by table `x`. Following the Tables.jl
+contract `Symbol` and `Int` must be supported. However, tables that allow other
+column indexing (e.g., using strings or integers other than `Int`) are allowed
+to accept such types of `col` argument. Passing `col` that is not a column
+of `x` can either throw an error or return `()` (this duality is allowed as
+some Tables.jl do not have schema).
 
 If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
 pairs for all columns that have metadata.

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -288,29 +288,32 @@ using a `sink` function to materialize the table.
 function allcombinations end
 
 """
-    metadata(x, [column])
+    metadata(x, [key])
 
 Return metadata associated with object `x` as an `AbstractDict{String}` object
 (or an object implementing the same interface).
 
-Optionally for Tables.jl tables a `columns` argument can be passed, in which case
-return metadata associated with the indicated column.
+Optionally `key` argument can be passed, in which case return metadata
+associated with the indicated key (this feature can be used, for example,
+by Tables.jl table to return metadata attached to columns of a table).
 
-Note that some systems, like Arrow.jl, might assume that metadata values are also `String`.
+Note that some systems, like Arrow.jl, might assume that metadata values are
+also `String`.
 """
 metadata(::T) where {T} = throw(ArgumentError("Metadata is currently not " *
                                               "supported for values of type $T"))
-metadata(::T, ::Any) where {T} = throw(ArgumentError("Column metadata is currently not " *
+metadata(::T, ::Any) where {T} = throw(ArgumentError("Key metadata is currently not " *
                                                      "supported for values of type $T"))
 
 """
-    hasmetadata(x, [column])
+    hasmetadata(x, [key])
 
 Return `true` if `x` has non-empty metadata, and return `false` if metadata is empty.
 Return `nothing` if `x` does not support metadata.
 
-Optionally for Tables.jl tables a `columns` argument can be passed, in which case
-return the same information about metadata associated with the indicated column.
+Optionally `key` argument can be passed, in which case return information if
+metadata is associated with the indicated key (this feature can be used, for example,
+by Tables.jl table to query about metadata attached to columns of a table).
 
 Note that some systems, like Arrow.jl, might assume that metadata values are also `String`.
 """

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -297,7 +297,7 @@ Note that some systems, like Arrow.jl, might assume that metadata values are
 also `String`.
 """
 metadata(::T) where {T} =
-    throw(ArgumentError("Metadata is currently not supported for values of type $T"))
+    throw(ArgumentError("Objects of type $T do not support metadata"))
 
 """
     colmetadata(table, column)
@@ -309,7 +309,7 @@ Note that some systems, like Arrow.jl, might assume that metadata values are
 also `String`.
 """
 colmetadata(::T, ::Any) where {T} =
-    throw(ArgumentError("Key metadata is currently not supported for values of type $T"))
+    throw(ArgumentError("Objects of type $T do not support column metadata"))
 
 """
     colmetadata(table)
@@ -323,7 +323,7 @@ The returned dictionary must contain columns `column` for which
 key must be `colmetadata(table, column)`.
 """
 colmetadata(::T) where {T} =
-    throw(ArgumentError("Key metadata is currently not supported for values of type $T"))
+    throw(ArgumentError("Objects of type $T do not support column metadata"))
 
 """
     hasmetadata(x)

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -305,6 +305,8 @@ metadata(::T) where {T} =
 Return metadata associated with column `column` of Tables.jl table `table` as an
 `AbstractDict{String}` object (or an object implementing the same interface).
 
+`column` should be any accepted column identifier by `table`, but at least `Symbol` must be supported.
+
 Note that some systems, like Arrow.jl, might assume that metadata values are
 also `String`.
 """
@@ -328,6 +330,9 @@ hasmetadata(::Any) = nothing
 Return `true` if column `column` of Tables.jl table `table` has non-empty metadata,
 and return `false` if metadata is empty.
 Return `nothing` if metadata is not supported for `column`.
+
+
+`column` should be any accepted column identifier by `table`, but at least `Symbol` must be supported.
 
 If `hascolmetadata` returns `Bool` then it is guaranteed that call to
 `colmetatada(table, columns)` will not throw an error.

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -291,7 +291,8 @@ const STYLE_INFO = """
 One of the uses of the metadata `style` is decision
 how the metadata should be propagated when `x` is transformed. This interface
 defines the `:none` style that indicates that metadata should not be propagated
-under transformations. All types supporting metadata allow at least this style.
+under any operations (it is only preserved when a copy of the source table is
+performed). All types supporting metadata allow at least this style.
 """
 
 const COL_INFO = """

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -338,7 +338,7 @@ metadata!(::T, ::AbstractString, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
 
 """
-    deletemetadata!(x, [key::AbstractString])
+    deletemetadata!(x, key::AbstractString)
 
 Delete metadata for object `x` for key `key` and return `x`
 (if metadata for `key` is not present do not perform any action).
@@ -347,7 +347,14 @@ If `x` does not support metadata deletion throw `ArgumentError`.
 """
 deletemetadata!(::T, ::AbstractString) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
-deletemetadata!(::T) where {T} =
+
+"""
+    emptymetadata!(x)
+
+Delete all metadata for object `x`.
+If `x` does not support metadata deletion throw `ArgumentError`.
+"""
+emptymetadata!(::T) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
 
 """
@@ -409,23 +416,29 @@ colmetadata!(::T, ::Symbol, ::AbstractString, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
 
 """
-    deletecolmetadata!(x, [col], [key::AbstractString])
+    deletecolmetadata!(x, col, key::AbstractString)
 
 Delete metadata for table `x` for column `col` for key `key` and return `x`
 (if metadata for `key` is not present do not perform any action).
-If `key` is not passed delete all metadata for table `x` for column `col`.
-If only `x` is passed delete all column level metadata for table `x`.
 If `x` does not support metadata deletion for column `col` throw `ArgumentError`.
 """
 deletecolmetadata!(::T, ::Symbol, ::AbstractString) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
 deletecolmetadata!(::T, ::Int, ::AbstractString) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
-deletecolmetadata!(::T, ::Symbol) where {T} =
+
+"""
+    emptycolmetadata!(x, [col])
+
+Delete all metadata for table `x` for column `col`.
+If `col` is not passed delete all column level metadata for table `x`.
+If `x` does not support metadata deletion for column `col` throw `ArgumentError`.
+"""
+emptycolmetadata!(::T, ::Symbol) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
-deletecolmetadata!(::T, ::Int) where {T} =
+emptycolmetadata!(::T, ::Int) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
-deletecolmetadata!(::T) where {T} =
+emptycolmetadata!(::T) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -312,20 +312,6 @@ colmetadata(::T, ::Any) where {T} =
     throw(ArgumentError("Objects of type $T do not support column metadata"))
 
 """
-    colmetadata(table)
-
-Return metadata associated with columns of Tables.jl table `table` as an
-`AbstractDict{<:Any, <:AbstractString{String}}` object (or an object implementing
-the same interface).
-
-The returned dictionary must contain columns `column` for which
-`hascolmetadata(table, column)` returns `true` and a value associated to such
-key must be `colmetadata(table, column)`.
-"""
-colmetadata(::T) where {T} =
-    throw(ArgumentError("Objects of type $T do not support column metadata"))
-
-"""
     hasmetadata(x)
 
 Return `true` if `x` has non-empty metadata, and return `false` if metadata is empty.
@@ -347,17 +333,5 @@ If `hascolmetadata` returns `Bool` then it is guaranteed that call to
 `colmetatada(table, columns)` will not throw an error.
 """
 hascolmetadata(::Any, ::Any) = nothing
-
-"""
-    hascolmetadata(table)
-
-Return `true` if at least one column of of Tables.jl table `table` has non-empty
-metadata, and return `false` if metadata is empty for all columns.
-Return `nothing` if metadata is not supported.
-
-If `hascolmetadata` returns `Bool` then it is guaranteed that call to
-`colmetatada(table)` will not throw an error.
-"""
-hascolmetadata(::Any) = nothing
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -417,11 +417,11 @@ If `key` is not passed delete all metadata for table `x` for column `col`.
 If only `x` is passed delete all column level metadata for table `x`.
 If `x` does not support metadata deletion for column `col` throw `ArgumentError`.
 """
-deletecolmetadata!(::T, :Symbol, ::AbstractString) where {T} =
+deletecolmetadata!(::T, ::Symbol, ::AbstractString) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
 deletecolmetadata!(::T, :Int, ::AbstractString) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
-deletecolmetadata!(::T, :Symbol) where {T} =
+deletecolmetadata!(::T, ::Symbol) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))
 deletecolmetadata!(::T, :Int) where {T} =
     throw(ArgumentError("Objects of type $T do not support metadata deletion"))

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -322,7 +322,7 @@ The returned dictionary must contain columns `column` for which
 `hascolmetadata(table, column)` returns `true` and a value associated to such
 key must be `colmetadata(table, column)`.
 """
-colmetadata(::T, ::Any) where {T} =
+colmetadata(::T) where {T} =
     throw(ArgumentError("Key metadata is currently not supported for values of type $T"))
 
 """
@@ -330,6 +330,9 @@ colmetadata(::T, ::Any) where {T} =
 
 Return `true` if `x` has non-empty metadata, and return `false` if metadata is empty.
 Return `nothing` if `x` does not support metadata.
+
+If `hasmetadata` returns `Bool` then it is guaranteed that call to `metatada(x)`
+will not throw an error.
 """
 hasmetadata(::Any) = nothing
 
@@ -338,7 +341,10 @@ hasmetadata(::Any) = nothing
 
 Return `true` if column `column` of Tables.jl table `table` has non-empty metadata,
 and return `false` if metadata is empty.
-Return `nothing` if metadata is not supported.
+Return `nothing` if metadata is not supported for `column`.
+
+If `hascolmetadata` returns `Bool` then it is guaranteed that call to
+`colmetatada(table, columns)` will not throw an error.
 """
 hascolmetadata(::Any, ::Any) = nothing
 
@@ -348,6 +354,9 @@ hascolmetadata(::Any, ::Any) = nothing
 Return `true` if at least one column of of Tables.jl table `table` has non-empty
 metadata, and return `false` if metadata is empty for all columns.
 Return `nothing` if metadata is not supported.
+
+If `hascolmetadata` returns `Bool` then it is guaranteed that call to
+`colmetatada(table)` will not throw an error.
 """
 hascolmetadata(::Any) = nothing
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -288,19 +288,17 @@ using a `sink` function to materialize the table.
 function allcombinations end
 
 const STYLE_INFO = """
-One of the uses of the metadata style information is decision
+One of the uses of the metadata `style` is decision
 how the metadata should be propagated when `x` is transformed. This interface
 defines the `:none` style that indicates that metadata should not be propagated
-under transformations. At least this style must be supported by any type
+under transformations. At least this style is allowed by any type
 defining support for metadata.
 """
 
 const COL_INFO = """
-`col` must be a type that is supported by table `x`. Following the Tables.jl
-contract `Symbol` and `Int` must be supported. However, tables that allow other
-column indexing (e.g., using strings or integers other than `Int`) are allowed
-to accept such types of `col` argument. Passing `col` that is not a column
-of `x` must throw an error.
+`col` must have a type that is supported by table `x` for column indexing.
+Following the Tables.jl contract `Symbol` and `Int` are always allowed.
+Passing `col` that is not a column of `x` throws an error.
 """
 
 """
@@ -308,11 +306,11 @@ of `x` must throw an error.
 
 Return metadata value associated with object `x` for key `key`.
 If `x` does not support metadata throw `ArgumentError`.
-If `x` supports metadata, but does not have a mapping for `key` throw `KeyError`.
+If `x` supports metadata, but does not have a mapping for `key` throw
+`KeyError`.
 
-Functions adding methods to `metadata` should define them only with
-`key::AbstractString` signature. Passing `key` that is not a string to
-`metadata` must throw `MethodError`.
+Passing `key` that is not an `AbstractString` to `metadata` throws
+`MethodError`.
 
 If `style=true` return a tuple of metadata value and metadata style. Metadata
 style is an additional information about the kind of metadata that is stored
@@ -334,13 +332,12 @@ metadatakeys(::Any) = ()
 """
     metadata!(x, key::AbstractString, value; style)
 
-Set metadata for object `x` for key `key` to have value `value` and style `style`
-and return `x`.
+Set metadata for object `x` for key `key` to have value `value`
+and style `style` and return `x`.
 If `x` does not support setting metadata throw `ArgumentError`.
 
-Functions adding methods to `metadata!` should define them only with
-`key::AbstractString` signature. Passing `key` that is not a string to
-`metadata` must throw `MethodError`.
+Passing `key` that is not an `AbstractString` to `metadata!`
+throws `MethodError`.
 
 $STYLE_INFO
 """
@@ -355,9 +352,8 @@ If `x` does not support metadata for column `col` throw `ArgumentError`. If `x`
 supports metadata, but does not have a mapping for column `col` for `key` throw
 `KeyError`.
 
-Functions adding methods to `colmetadata` should define them only with
-`key::AbstractString` signature. Passing `key` that is not a string to
-`metadata` must throw `MethodError`.
+Passing `key` that is not an `AbstractString` to `colmetadata`
+throws `MethodError`.
 
 $COL_INFO
 
@@ -375,20 +371,19 @@ colmetadata(::T, ::Symbol, ::AbstractString; style::Bool=false) where {T} =
 """
     colmetadatakeys(x, [col])
 
-If `col` is passed return an iterator of metadata keys for which
-`metadata(x, col, key)` returns a metadata value.
-If `x` does not support metadata for column `col` return `()`.
+If `col` is passed return an iterator of metadata keys for which `metadata(x,
+col, key)` returns a metadata value. If `x` does not support metadata for column
+`col` return `()`.
 
-`col` must be a type that is supported by table `x`. Following the Tables.jl
-contract `Symbol` and `Int` must be supported. However, tables that allow other
-column indexing (e.g., using strings or integers other than `Int`) are allowed
-to accept such types of `col` argument. Passing `col` that is not a column
-of `x` can either throw an error or return `()` (this duality is allowed as
-some Tables.jl do not have schema).
+`col` must have a type that is supported by table `x` for column indexing.
+Following the Tables.jl contract `Symbol` and `Int` are always allowed. Passing
+`col` that is not a column of `x` can either throws an error (this is a
+preferred behavior if it is possible) or returns `()` (this duality is allowed
+as some Tables.jl tables do not have schema).
 
 If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
-pairs for all columns that have metadata.
-If `x` does not support metadata for any column return `()`.
+pairs for all columns that have metadata. If `x` does not support metadata for
+any column return `()`.
 """
 colmetadatakeys(::Any, ::Int) = ()
 colmetadatakeys(::Any, ::Symbol) = ()
@@ -401,9 +396,8 @@ Set metadata for table `x` for column `col` for key `key` to have value `value`
 and style `style`.
 If `x` does not support setting metadata for column `col` throw `ArgumentError`.
 
-Functions adding methods to `colmetadata!` should define them only with
-`key::AbstractString` signature. Passing `key` that is not a string to
-`metadata` must throw `MethodError`.
+Passing `key` that is not an `AbstractString` to `colmetadata!`
+throws `MethodError`.
 
 $COL_INFO
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -342,7 +342,6 @@ metadata!(::T, ::AbstractString, ::Any; style) where {T} =
 
 Delete metadata for object `x` for key `key` and return `x`
 (if metadata for `key` is not present do not perform any action).
-If `key` is not passed delete all metadata for object `x`.
 If `x` does not support metadata deletion throw `ArgumentError`.
 """
 deletemetadata!(::T, ::AbstractString) where {T} =

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -314,8 +314,6 @@ Return `nothing` if `x` does not support metadata.
 If the optional `key` argument is passed, return information about whether
 metadata is associated with the indicated key (this feature can be used, for example,
 to query about metadata attached to a given column in a Tables.jl table).
-
-Note that some systems, like Arrow.jl, might assume that metadata values are also `String`.
 """
 hasmetadata(::Any) = nothing
 hasmetadata(::Any, ::Any) = nothing

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -288,10 +288,11 @@ using a `sink` function to materialize the table.
 function allcombinations end
 
 """
-    getmetadata(x, ...)
+    metadata(x)
 
-Return metadata associated with object `x` or `nothing` if it doest not support metadata.
+Return metadata associated with object `x` as an `AbstractDict{String}` object
+(or an object implementing the same interface), or `nothing` if `x` does not support metadata.
 """
-getmetadata(::Any) = nothing
+metadata(::Any) = nothing
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -292,6 +292,8 @@ function allcombinations end
 
 Return metadata associated with object `x` as an `AbstractDict{String}` object
 (or an object implementing the same interface), or `nothing` if `x` does not support metadata.
+
+Note that some systems, like Arrow.jl, might assume that metadata values are also `String`.
 """
 metadata(::Any) = nothing
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -290,7 +290,7 @@ function allcombinations end
 const STYLE_INFO = """
 One of the uses of the metadata `style` is decision
 how the metadata should be propagated when `x` is transformed. This interface
-defines the `:none` style that indicates that metadata should not be propagated
+defines the `:default` style that indicates that metadata should not be propagated
 under any operations (it is only preserved when a copy of the source table is
 performed). All types supporting metadata allow at least this style.
 """

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -290,7 +290,7 @@ function allcombinations end
 const STYLE_INFO = """
 One of the uses of the metadata style information is decision
 how the metadata should be propagated when `x` is transformed. This interface
-defines `:none` style that indicates that metadata should not be propagated
+defines the `:none` style that indicates that metadata should not be propagated
 under transformations. At least this style must be supported by any type
 defining support for metadata.
 """
@@ -319,7 +319,7 @@ metadata(::Any, ::Any, default; full::Bool=false) = full ? (default, :none) : de
     metadatakeys(x)
 
 Return an iterator of metadata keys for which `metadata(x, key)` returns a
-metdata value. If `x` does not support metadata return `()`.
+metadata value. If `x` does not support metadata return `()`.
 """
 metadatakeys(::Any) = ()
 
@@ -361,7 +361,7 @@ colmetadata(::Any, ::Any, ::Any, default; full::Bool=false) = full ? (default, :
     colmetadatakeys(x, [col])
 
 If `col` is passed return an iterator of metadata keys for which
-`metadata(x, col, key)` returns a metdata value.
+`metadata(x, col, key)` returns a metadata value.
 If `x` does not support metadata for column `col` return `()`.
 
 If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -293,17 +293,17 @@ function allcombinations end
 Return metadata associated with object `x` as an `AbstractDict{String}` object
 (or an object implementing the same interface).
 
-Optionally `key` argument can be passed, in which case return metadata
+If the optional `key` argument is passed, return metadata
 associated with the indicated key (this feature can be used, for example,
-by Tables.jl table to return metadata attached to columns of a table).
+to return metadata attached to a given column in a Tables.jl table).
 
 Note that some systems, like Arrow.jl, might assume that metadata values are
 also `String`.
 """
-metadata(::T) where {T} = throw(ArgumentError("Metadata is currently not " *
-                                              "supported for values of type $T"))
-metadata(::T, ::Any) where {T} = throw(ArgumentError("Key metadata is currently not " *
-                                                     "supported for values of type $T"))
+metadata(::T) where {T} =
+    throw(ArgumentError("Metadata is currently not supported for values of type $T"))
+metadata(::T, ::Any) where {T} =
+    throw(ArgumentError("Key metadata is currently not supported for values of type $T"))
 
 """
     hasmetadata(x, [key])
@@ -311,9 +311,9 @@ metadata(::T, ::Any) where {T} = throw(ArgumentError("Key metadata is currently 
 Return `true` if `x` has non-empty metadata, and return `false` if metadata is empty.
 Return `nothing` if `x` does not support metadata.
 
-Optionally `key` argument can be passed, in which case return information if
+If the optional `key` argument is passed, return information about whether
 metadata is associated with the indicated key (this feature can be used, for example,
-by Tables.jl table to query about metadata attached to columns of a table).
+to query about metadata attached to a given column in a Tables.jl table).
 
 Note that some systems, like Arrow.jl, might assume that metadata values are also `String`.
 """

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -287,66 +287,100 @@ using a `sink` function to materialize the table.
 """
 function allcombinations end
 
+const STYLE_INFO = """
+One of the uses of the metadata style information is decision
+how the metadata should be propagated when `x` is transformed. This interface
+defines `:none` style that indicates that metadata should not be propagated
+under transformations. At least this style must be supported by any type
+defining support for metadata.
 """
-    metadata(x)
-
-Return metadata associated with object `x` as an `AbstractDict{String}` object
-(or an object implementing the same interface).
-
-Note that some systems, like Arrow.jl, might assume that metadata values are
-also `String`.
-"""
-metadata(::T) where {T} =
-    throw(ArgumentError("Objects of type $T do not support metadata"))
 
 """
-    colmetadata(table, column)
+    metadata(x, key, [default]; full::Bool=false)
 
-Return metadata associated with column `column` of Tables.jl table `table` as an
-`AbstractDict{String}` object (or an object implementing the same interface).
+Return metadata value associated with object `x` for key `key`.
+If `x` does not support metadata throw `ArgumentError`.
+If `x` supports metadata, but does not have a mapping for `key` throw `KeyError`.
 
-`column` should be any accepted column identifier by `table`, but at least `Symbol` must be supported.
+If `full=true` return a tuple of metadata value and metadata style. Metadata
+style is an additional information about the kind of metadata that is stored
+for the `key`.
 
-Note that some systems, like Arrow.jl, might assume that metadata values are
-also `String`.
+$STYLE_INFO
+
+If `default` is passed then return it if `x` does not support metadata or
+does not have a mapping for `key`. The style of `default` value is `:none`.
 """
-colmetadata(::T, ::Any) where {T} =
-    throw(ArgumentError("Objects of type $T do not support column metadata"))
-
-"""
-    hasmetadata(x)
-
-Return `true` if `x` has non-empty metadata, and return `false` if metadata is empty.
-Return `nothing` if `x` does not support metadata.
-
-If `hasmetadata` returns `Bool` then it is guaranteed that call to `metatada(x)`
-will not throw an error.
-"""
-hasmetadata(::Any) = nothing
+metadata(::T, ::Any; full::Bool=false) where {T} =
+    throw(ArgumentError("Objects of type $T do not support getting metadata"))
+metadata(::Any, ::Any, default; full::Bool=false) = full ? (default, :none) : default
 
 """
-    hascolmetadata(table, column)
+    metadatakeys(x)
 
-Return `true` if column `column` of Tables.jl table `table` has non-empty metadata,
-and return `false` if metadata is empty.
-Return `nothing` if metadata is not supported for `column`.
-
-`column` should be any accepted column identifier by `table`, but at least `Symbol` must be supported.
-
-If `hascolmetadata` returns `Bool` then it is guaranteed that call to
-`colmetatada(table, columns)` will not throw an error.
+Return an iterator of metadata keys for which `metadata(x, key)` returns a
+metdata value. If `x` does not support metadata return `()`.
 """
-hascolmetadata(::Any, ::Any) = nothing
+metadatakeys(::Any) = ()
 
 """
-    hascolmetadata(table)
+    metadata!(x, key, value; style)
 
-Return `true` if there is exists at least one column `column` of Tables.jl table
-`table` for which `hascolmetadata(table, column)` returns `true`; otherwise
-return `false`.
+Set metadata for object `x` for key `key` to have value `value` and style `style`
+and return `x`.
+If `x` does not support setting metadata throw `ArgumentError`.
 
-Return `nothing` if metadata is not supported.
+$STYLE_INFO
 """
-hascolmetadata(::Any) = nothing
+metadata!(::T, ::Any; style) where {T} =
+    throw(ArgumentError("Objects of type $T do not support setting metadata"))
+
+"""
+    colmetadata(x, col, key, [default]; full::Bool=false)
+
+Return metadata value associated with table `x` for column `col` and key `key`.
+If `x` does not support metadata for column `col` throw `ArgumentError`. If `x`
+supports metadata, but does not have a mapping for column `col` for `key` throw
+`KeyError`.
+
+If `full=true` return a tuple of metadata value and metadata style. Metadata
+style is an additional information about the kind of metadata that is stored for
+the `key`.
+
+$STYLE_INFO
+
+If `default` is passed then return it if `x` does not support metadata for
+column `col` or does not have a mapping for `key` for column `col`. The style of
+`default` value is `:none`.
+"""
+colmetadata(::T, ::Any, ::Any; full::Bool=false) where {T} =
+    throw(ArgumentError("Objects of type $T do not support getting column metadata"))
+colmetadata(::Any, ::Any, ::Any, default; full::Bool=false) = full ? (default, :none) : default
+
+"""
+    colmetadatakeys(x, [col])
+
+If `col` is passed return an iterator of metadata keys for which
+`metadata(x, col, key)` returns a metdata value.
+If `x` does not support metadata for column `col` return `()`.
+
+If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
+pairs for all columns that have metadata.
+If `x` does not support metadata for any column return `()`.
+"""
+colmetadatakeys(::Any, ::Any) = ()
+colmetadatakeys(::Any) = ()
+
+"""
+    colmetadata!(x, key, value; style)
+
+Set metadata for table `x` for column `col` for key `key` to have value `value`
+and style `style`.
+If `x` does not support setting metadata for column `col` throw `ArgumentError`.
+
+$STYLE_INFO
+"""
+colmetadata!(::T, ::Any, ::Any; style) where {T} =
+    throw(ArgumentError("Objects of type $T do not support setting metadata"))
 
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -291,8 +291,7 @@ const STYLE_INFO = """
 One of the uses of the metadata `style` is decision
 how the metadata should be propagated when `x` is transformed. This interface
 defines the `:none` style that indicates that metadata should not be propagated
-under transformations. At least this style is allowed by any type
-defining support for metadata.
+under transformations. All types supporting metadata allow at least this style.
 """
 
 const COL_INFO = """
@@ -308,9 +307,6 @@ Return metadata value associated with object `x` for key `key`.
 If `x` does not support metadata throw `ArgumentError`.
 If `x` supports metadata, but does not have a mapping for `key` throw
 `KeyError`.
-
-Passing `key` that is not an `AbstractString` to `metadata` throws
-`MethodError`.
 
 If `style=true` return a tuple of metadata value and metadata style. Metadata
 style is an additional information about the kind of metadata that is stored
@@ -336,9 +332,6 @@ Set metadata for object `x` for key `key` to have value `value`
 and style `style` and return `x`.
 If `x` does not support setting metadata throw `ArgumentError`.
 
-Passing `key` that is not an `AbstractString` to `metadata!`
-throws `MethodError`.
-
 $STYLE_INFO
 """
 metadata!(::T, ::AbstractString, ::Any; style) where {T} =
@@ -351,9 +344,6 @@ Return metadata value associated with table `x` for column `col` and key `key`.
 If `x` does not support metadata for column `col` throw `ArgumentError`. If `x`
 supports metadata, but does not have a mapping for column `col` for `key` throw
 `KeyError`.
-
-Passing `key` that is not an `AbstractString` to `colmetadata`
-throws `MethodError`.
 
 $COL_INFO
 
@@ -379,11 +369,11 @@ col, key)` returns a metadata value. If `x` does not support metadata for column
 Following the Tables.jl contract `Symbol` and `Int` are always allowed. Passing
 `col` that is not a column of `x` can either throws an error (this is a
 preferred behavior if it is possible) or returns `()` (this duality is allowed
-as some Tables.jl tables do not have schema).
+as some Tables.jl tables do not have a schema).
 
 If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
-pairs for all columns that have metadata. If `x` does not support metadata for
-any column return `()`.
+pairs for all columns that have metadata. If `x` does not support column
+metadata return `()`.
 """
 colmetadatakeys(::Any, ::Int) = ()
 colmetadatakeys(::Any, ::Symbol) = ()
@@ -395,9 +385,6 @@ colmetadatakeys(::Any) = ()
 Set metadata for table `x` for column `col` for key `key` to have value `value`
 and style `style`.
 If `x` does not support setting metadata for column `col` throw `ArgumentError`.
-
-Passing `key` that is not an `AbstractString` to `colmetadata!`
-throws `MethodError`.
 
 $COL_INFO
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -295,25 +295,33 @@ under transformations. At least this style must be supported by any type
 defining support for metadata.
 """
 
+const COL_INFO = """
+`col` must be a type that is supported by table `x`. Following the Tables.jl
+contract `Symbol` and `Int` must be supported. However, tables that allow other
+column indexing (e.g., using strings or integers other than `Int`) are allowed
+to accept such types of `col` argument. Passing `col` that is not a column
+of `x` must throw an error.
 """
-    metadata(x, key, [default]; full::Bool=false)
+
+"""
+    metadata(x, key::AbstractString; style::Bool=false)
 
 Return metadata value associated with object `x` for key `key`.
 If `x` does not support metadata throw `ArgumentError`.
 If `x` supports metadata, but does not have a mapping for `key` throw `KeyError`.
 
-If `full=true` return a tuple of metadata value and metadata style. Metadata
+Functions adding methods to `metadata` should define them only with
+`key::AbstractString` signature. Passing `key` that is not a string to
+`metadata` must throw `MethodError`.
+
+If `style=true` return a tuple of metadata value and metadata style. Metadata
 style is an additional information about the kind of metadata that is stored
 for the `key`.
 
 $STYLE_INFO
-
-If `default` is passed then return it if `x` does not support metadata or
-does not have a mapping for `key`. The style of `default` value is `:none`.
 """
-metadata(::T, ::Any; full::Bool=false) where {T} =
+metadata(::T, ::AbstractString; style::Bool=false) where {T} =
     throw(ArgumentError("Objects of type $T do not support getting metadata"))
-metadata(::Any, ::Any, default; full::Bool=false) = full ? (default, :none) : default
 
 """
     metadatakeys(x)
@@ -324,38 +332,45 @@ metadata value. If `x` does not support metadata return `()`.
 metadatakeys(::Any) = ()
 
 """
-    metadata!(x, key, value; style)
+    metadata!(x, key::AbstractString, value; style)
 
 Set metadata for object `x` for key `key` to have value `value` and style `style`
 and return `x`.
 If `x` does not support setting metadata throw `ArgumentError`.
 
+Functions adding methods to `metadata!` should define them only with
+`key::AbstractString` signature. Passing `key` that is not a string to
+`metadata` must throw `MethodError`.
+
 $STYLE_INFO
 """
-metadata!(::T, ::Any, ::Any; style) where {T} =
+metadata!(::T, ::AbstractString, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
 
 """
-    colmetadata(x, col, key, [default]; full::Bool=false)
+    colmetadata(x, col, key::AbstractString; style::Bool=false)
 
 Return metadata value associated with table `x` for column `col` and key `key`.
 If `x` does not support metadata for column `col` throw `ArgumentError`. If `x`
 supports metadata, but does not have a mapping for column `col` for `key` throw
 `KeyError`.
 
-If `full=true` return a tuple of metadata value and metadata style. Metadata
+Functions adding methods to `colmetadata` should define them only with
+`key::AbstractString` signature. Passing `key` that is not a string to
+`metadata` must throw `MethodError`.
+
+$COL_INFO
+
+If `style=true` return a tuple of metadata value and metadata style. Metadata
 style is an additional information about the kind of metadata that is stored for
 the `key`.
 
 $STYLE_INFO
-
-If `default` is passed then return it if `x` does not support metadata for
-column `col` or does not have a mapping for `key` for column `col`. The style of
-`default` value is `:none`.
 """
-colmetadata(::T, ::Any, ::Any; full::Bool=false) where {T} =
+colmetadata(::T, ::Int, ::AbstractString; style::Bool=false) where {T} =
     throw(ArgumentError("Objects of type $T do not support getting column metadata"))
-colmetadata(::Any, ::Any, ::Any, default; full::Bool=false) = full ? (default, :none) : default
+colmetadata(::T, ::Symbol, ::AbstractString; style::Bool=false) where {T} =
+    throw(ArgumentError("Objects of type $T do not support getting column metadata"))
 
 """
     colmetadatakeys(x, [col])
@@ -364,23 +379,34 @@ If `col` is passed return an iterator of metadata keys for which
 `metadata(x, col, key)` returns a metadata value.
 If `x` does not support metadata for column `col` return `()`.
 
+$COL_INFO
+
 If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
 pairs for all columns that have metadata.
 If `x` does not support metadata for any column return `()`.
 """
-colmetadatakeys(::Any, ::Any) = ()
+colmetadatakeys(::Any, ::Int) = ()
+colmetadatakeys(::Any, ::Symbol) = ()
 colmetadatakeys(::Any) = ()
 
 """
-    colmetadata!(x, key, value; style)
+    colmetadata!(x, col, key::AbstractString, value; style)
 
 Set metadata for table `x` for column `col` for key `key` to have value `value`
 and style `style`.
 If `x` does not support setting metadata for column `col` throw `ArgumentError`.
 
+Functions adding methods to `colmetadata!` should define them only with
+`key::AbstractString` signature. Passing `key` that is not a string to
+`metadata` must throw `MethodError`.
+
+$COL_INFO
+
 $STYLE_INFO
 """
-colmetadata!(::T, ::Any, ::Any, ::Any; style) where {T} =
+colmetadata!(::T, ::Int, ::AbstractString, ::Any; style) where {T} =
+    throw(ArgumentError("Objects of type $T do not support setting metadata"))
+colmetadata!(::T, ::Symbol, ::AbstractString, ::Any; style) where {T} =
     throw(ArgumentError("Objects of type $T do not support setting metadata"))
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,7 +228,11 @@ end
     @test_throws ArgumentError DataAPI.colmetadata!(1, :col, "a", 10, style=:none)
     @test_throws ArgumentError DataAPI.colmetadata(1, :col, "a")
     @test_throws ArgumentError DataAPI.colmetadata(1, :col, "a", style=true)
+    @test_throws ArgumentError DataAPI.colmetadata!(1, 1, "a", 10, style=:none)
+    @test_throws ArgumentError DataAPI.colmetadata(1, 1, "a")
+    @test_throws ArgumentError DataAPI.colmetadata(1, 1, "a", style=true)
     @test DataAPI.colmetadatakeys(1, :col) == ()
+    @test DataAPI.colmetadatakeys(1, 1) == ()
     @test DataAPI.colmetadatakeys(1) == ()
 
     tm = TestMeta()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ function DataAPI.metadata!(x::TestMeta, key::AbstractString, value; style)
 end
 
 DataAPI.deletemetadata!(x::TestMeta, key::AbstractString) = delete!(x.table, key)
-DataAPI.deletemetadata!(x::TestMeta) = empty!(x.table)
+DataAPI.emptymetadata!(x::TestMeta) = empty!(x.table)
 
 function DataAPI.colmetadata(x::TestMeta, col::Symbol, key::AbstractString; style::Bool=false)
     return style ? x.col[col][key] : x.col[col][key][1]
@@ -72,7 +72,7 @@ function DataAPI.deletecolmetadata!(x::TestMeta, col::Symbol, key::AbstractStrin
     return x
 end
 
-function DataAPI.deletecolmetadata!(x::TestMeta, col::Symbol)
+function DataAPI.emptycolmetadata!(x::TestMeta, col::Symbol)
     if haskey(x.col, col)
         delete!(x.col, col)
     else
@@ -81,7 +81,7 @@ function DataAPI.deletecolmetadata!(x::TestMeta, col::Symbol)
     return x
 end
 
-DataAPI.deletecolmetadata!(x::TestMeta) = empty!(x.col)
+DataAPI.emptycolmetadata!(x::TestMeta) = empty!(x.col)
 
 @testset "DataAPI" begin
 
@@ -249,17 +249,17 @@ end
 @testset "metadata" begin
     @test_throws ArgumentError DataAPI.metadata!(1, "a", 10, style=:none)
     @test_throws ArgumentError DataAPI.deletemetadata!(1, "a")
-    @test_throws ArgumentError DataAPI.deletemetadata!(1)
+    @test_throws ArgumentError DataAPI.emptymetadata!(1)
     @test_throws ArgumentError DataAPI.metadata(1, "a")
     @test_throws ArgumentError DataAPI.metadata(1, "a", style=true)
     @test DataAPI.metadatakeys(1) == ()
 
     @test_throws ArgumentError DataAPI.colmetadata!(1, :col, "a", 10, style=:none)
     @test_throws ArgumentError DataAPI.deletecolmetadata!(1, :col, "a")
-    @test_throws ArgumentError DataAPI.deletecolmetadata!(1, :col)
+    @test_throws ArgumentError DataAPI.emptycolmetadata!(1, :col)
     @test_throws ArgumentError DataAPI.deletecolmetadata!(1, 1, "a")
-    @test_throws ArgumentError DataAPI.deletecolmetadata!(1, 1)
-    @test_throws ArgumentError DataAPI.deletecolmetadata!(1)
+    @test_throws ArgumentError DataAPI.emptycolmetadata!(1, 1)
+    @test_throws ArgumentError DataAPI.emptycolmetadata!(1)
     @test_throws ArgumentError DataAPI.colmetadata(1, :col, "a")
     @test_throws ArgumentError DataAPI.colmetadata(1, :col, "a", style=true)
     @test_throws ArgumentError DataAPI.colmetadata!(1, 1, "a", 10, style=:none)
@@ -280,7 +280,7 @@ end
     DataAPI.deletemetadata!(tm, "a")
     @test isempty(DataAPI.metadatakeys(tm))
     @test DataAPI.metadata!(tm, "a", "100", style=:note) == tm
-    DataAPI.deletemetadata!(tm)
+    DataAPI.emptymetadata!(tm)
     @test isempty(DataAPI.metadatakeys(tm))
 
     @test DataAPI.colmetadatakeys(tm) == ()
@@ -297,10 +297,10 @@ end
     DataAPI.deletecolmetadata!(tm, :col, "a")
     @test isempty(DataAPI.colmetadatakeys(tm, :col))
     @test DataAPI.colmetadata!(tm, :col, "a", "100", style=:note) == tm
-    DataAPI.deletecolmetadata!(tm, :col)
+    DataAPI.emptycolmetadata!(tm, :col)
     @test isempty(DataAPI.colmetadatakeys(tm, :col))
     @test DataAPI.colmetadata!(tm, :col, "a", "100", style=:note) == tm
-    DataAPI.deletecolmetadata!(tm)
+    DataAPI.emptycolmetadata!(tm)
     @test isempty(DataAPI.colmetadatakeys(tm))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -292,14 +292,14 @@ end
     @test_throws KeyError DataAPI.colmetadata(tm, :col2, "a", style=true)
     @test DataAPI.colmetadata(tm, :col, "a") == "100"
     @test DataAPI.colmetadata(tm, :col, "a", style=true) == ("100", :note)
-    @test DataAPI.deletecolmetadata!(tm, :col, "a")
-    @test DataAPI.colmetadatakeys(tm, :col) == ()
+    DataAPI.deletecolmetadata!(tm, :col, "a")
+    @test isempty(DataAPI.colmetadatakeys(tm, :col))
     @test DataAPI.colmetadata!(tm, :col, "a", "100", style=:note) == tm
-    @test DataAPI.deletecolmetadata!(tm, :col)
-    @test DataAPI.colmetadatakeys(tm, :col) == ()
+    DataAPI.deletecolmetadata!(tm, :col)
+    @test isempty(DataAPI.colmetadatakeys(tm, :col))
     @test DataAPI.colmetadata!(tm, :col, "a", "100", style=:note) == tm
-    @test DataAPI.deletecolmetadata!(tm)
-    @test DataAPI.colmetadatakeys(tm) == ()
+    DataAPI.deletecolmetadata!(tm)
+    @test isempty(DataAPI.colmetadatakeys(tm))
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,8 @@ DataAPI.colmetadata(x::TestArray, col) =
 DataAPI.colmetadata(x::TestArray) = Dict("x" => Dict("name" => col))
 
 DataAPI.hasmetadata(x::TestArray) = true
-DataAPI.colhasmetadata(x::TestArray) = true
-DataAPI.colhasmetadata(x::TestArray, col) = col === "x"
+DataAPI.hascolmetadata(x::TestArray) = true
+DataAPI.hascolmetadata(x::TestArray, col) = col === "x"
 
 @testset "DataAPI" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,7 +176,7 @@ end
 
 @testset "metadata" begin
     @test isnothing(DataAPI.metadata(1))
-    @test DataAPI.metadata(TestArray([1, 2])) === Dict("length => 2)
+    @test DataAPI.metadata(TestArray([1, 2])) === Dict("length" => 2)
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,8 +185,6 @@ end
     @test_throws ArgumentError DataAPI.metadata(1)
     @test DataAPI.hascolmetadata(1, 1) === nothing
     @test_throws ArgumentError DataAPI.colmetadata(1, 1)
-    @test DataAPI.hascolmetadata(1) === nothing
-    @test_throws ArgumentError DataAPI.colmetadata(1)
 
 
     @test DataAPI.hasmetadata(TestArray([1, 2]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ DataAPI.colmetadata(x::TestArray, col) =
 
 DataAPI.hasmetadata(x::TestArray) = true
 DataAPI.hascolmetadata(x::TestArray, col) = col === "x" ? true : nothing
+DataAPI.hascolmetadata(x::TestArray) = true
 
 @testset "DataAPI" begin
 
@@ -185,10 +186,11 @@ end
     @test_throws ArgumentError DataAPI.metadata(1)
     @test DataAPI.hascolmetadata(1, 1) === nothing
     @test_throws ArgumentError DataAPI.colmetadata(1, 1)
-
+    @test DataAPI.hascolmetadata(1) === nothing
 
     @test DataAPI.hasmetadata(TestArray([1, 2]))
     @test DataAPI.metadata(TestArray([1, 2])) == Dict("length" => 2)
+    @test DataAPI.hascolmetadata(TestArray([1, 2])) === true
     @test DataAPI.hascolmetadata(TestArray([1, 2]), "x") === true
     @test DataAPI.colmetadata(TestArray([1, 2]), "x") == Dict("name" => "x")
     @test DataAPI.hascolmetadata(TestArray([1, 2]), "y") === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,14 +247,14 @@ end
 end
 
 @testset "metadata" begin
-    @test_throws ArgumentError DataAPI.metadata!(1, "a", 10, style=:none)
+    @test_throws ArgumentError DataAPI.metadata!(1, "a", 10, style=:default)
     @test_throws ArgumentError DataAPI.deletemetadata!(1, "a")
     @test_throws ArgumentError DataAPI.emptymetadata!(1)
     @test_throws ArgumentError DataAPI.metadata(1, "a")
     @test_throws ArgumentError DataAPI.metadata(1, "a", style=true)
     @test DataAPI.metadatakeys(1) == ()
 
-    @test_throws ArgumentError DataAPI.colmetadata!(1, :col, "a", 10, style=:none)
+    @test_throws ArgumentError DataAPI.colmetadata!(1, :col, "a", 10, style=:default)
     @test_throws ArgumentError DataAPI.deletecolmetadata!(1, :col, "a")
     @test_throws ArgumentError DataAPI.emptycolmetadata!(1, :col)
     @test_throws ArgumentError DataAPI.deletecolmetadata!(1, 1, "a")
@@ -262,7 +262,7 @@ end
     @test_throws ArgumentError DataAPI.emptycolmetadata!(1)
     @test_throws ArgumentError DataAPI.colmetadata(1, :col, "a")
     @test_throws ArgumentError DataAPI.colmetadata(1, :col, "a", style=true)
-    @test_throws ArgumentError DataAPI.colmetadata!(1, 1, "a", 10, style=:none)
+    @test_throws ArgumentError DataAPI.colmetadata!(1, 1, "a", 10, style=:default)
     @test_throws ArgumentError DataAPI.colmetadata(1, 1, "a")
     @test_throws ArgumentError DataAPI.colmetadata(1, 1, "a", style=true)
     @test DataAPI.colmetadatakeys(1, :col) == ()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,7 +176,7 @@ end
 
 @testset "metadata" begin
     @test isnothing(DataAPI.metadata(1))
-    @test DataAPI.metadata(TestArray([1, 2])) === Dict("length" => 2)
+    @test DataAPI.metadata(TestArray([1, 2])) == Dict("length" => 2)
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ DataAPI.colmetadata(x::TestArray) = Dict("x" => DataAPI.colmetadata(x, "x"))
 
 DataAPI.hasmetadata(x::TestArray) = true
 DataAPI.hascolmetadata(x::TestArray) = true
-DataAPI.hascolmetadata(x::TestArray, col) = col === "x"
+DataAPI.hascolmetadata(x::TestArray, col) = col === "x" ? true : nothing
 
 @testset "DataAPI" begin
 
@@ -183,23 +183,22 @@ end
 end
 
 @testset "metadata" begin
-    @test_throws ArgumentError DataAPI.metadata(1)
     @test DataAPI.hasmetadata(1) === nothing
-    @test_throws ArgumentError DataAPI.metadata(1, 1)
+    @test_throws ArgumentError DataAPI.metadata(1)
     @test DataAPI.hascolmetadata(1, 1) === nothing
     @test_throws ArgumentError DataAPI.colmetadata(1, 1)
     @test DataAPI.hascolmetadata(1) === nothing
     @test_throws ArgumentError DataAPI.colmetadata(1)
 
 
-    @test DataAPI.metadata(TestArray([1, 2])) == Dict("length" => 2)
     @test DataAPI.hasmetadata(TestArray([1, 2]))
-    @test DataAPI.colmetadata(TestArray([1, 2]), "x") == Dict("name" => "col")
-    @test DataAPI.hascolmetadata(TestArray([1, 2]), "x") == true
+    @test DataAPI.metadata(TestArray([1, 2])) == Dict("length" => 2)
+    @test DataAPI.hascolmetadata(TestArray([1, 2]), "x") === true
+    @test DataAPI.colmetadata(TestArray([1, 2]), "x") == Dict("name" => "x")
+    @test DataAPI.hascolmetadata(TestArray([1, 2]), "y") === nothing
     @test_throws ArgumentError DataAPI.colmetadata(TestArray([1, 2]), "y")
-    @test DataAPI.hascolmetadata(TestArray([1, 2]), "y") == false
-    @test DataAPI.colmetadata(TestArray([1, 2])) == Dict("x" => Dict("name" => "col"))
-    @test DataAPI.hascolmetadata(TestArray([1, 2])) == true
+    @test DataAPI.hascolmetadata(TestArray([1, 2])) === true
+    @test DataAPI.colmetadata(TestArray([1, 2])) == Dict("x" => Dict("name" => "x"))
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -275,10 +275,10 @@ end
     @test_throws KeyError DataAPI.metadata(tm, "b", style=true)
     @test DataAPI.metadata(tm, "a") == "100"
     @test DataAPI.metadata(tm, "a", style=true) == ("100", :note)
-    DataAPI.deletemetadata!(1, "a")
+    DataAPI.deletemetadata!(tm, "a")
     @test isempty(DataAPI.metadatakeys(tm))
     @test DataAPI.metadata!(tm, "a", "100", style=:note) == tm
-    DataAPI.deletemetadata!(1)
+    DataAPI.deletemetadata!(tm)
     @test isempty(DataAPI.metadatakeys(tm))
 
     @test DataAPI.colmetadatakeys(tm) == ()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ end
 Base.size(x::TestArray) = size(x.x)
 Base.getindex(x::TestArray, i) = x.x[i]
 DataAPI.levels(x::TestArray) = reverse(DataAPI.levels(x.x))
+DataAPI.metadata(x::TestArray) = Dict("length" => length(x))
 
 @testset "DataAPI" begin
 
@@ -171,6 +172,11 @@ end
 @testset "unwrap" begin
     @test DataAPI.unwrap(1) === 1
     @test DataAPI.unwrap(missing) === missing
+end
+
+@testset "metadata" begin
+    @test isnothing(DataAPI.metadata(1))
+    @test DataAPI.metadata(TestArray([1, 2])) === Dict("length => 2)
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,6 +180,8 @@ end
 @testset "metadata" begin
     @test_throws ArgumentError DataAPI.metadata(1)
     @test DataAPI.hasmetadata(1) === nothing
+    @test_throws ArgumentError DataAPI.metadata(1, 1)
+    @test DataAPI.hasmetadata(1, 1) === nothing
     @test DataAPI.metadata(TestArray([1, 2])) == Dict("length" => 2)
     @test DataAPI.hasmetadata(TestArray([1, 2]))
     @test DataAPI.metadata(TestArray([1, 2]), "col") == Dict("name" => "col")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,10 +9,15 @@ end
 Base.size(x::TestArray) = size(x.x)
 Base.getindex(x::TestArray, i) = x.x[i]
 DataAPI.levels(x::TestArray) = reverse(DataAPI.levels(x.x))
+
 DataAPI.metadata(x::TestArray) = Dict("length" => length(x))
-DataAPI.metadata(x::TestArray, col) = Dict("name" => col)
+DataAPI.colmetadata(x::TestArray, col) =
+    col === "x" ? Dict("name" => col) : throw ArgumentError("no metadata")
+DataAPI.colmetadata(x::TestArray) = Dict("x" => Dict("name" => col))
+
 DataAPI.hasmetadata(x::TestArray) = true
-DataAPI.hasmetadata(x::TestArray, col) = true
+DataAPI.colhasmetadata(x::TestArray) = true
+DataAPI.colhasmetadata(x::TestArray, col) = col === "x"
 
 @testset "DataAPI" begin
 
@@ -181,11 +186,20 @@ end
     @test_throws ArgumentError DataAPI.metadata(1)
     @test DataAPI.hasmetadata(1) === nothing
     @test_throws ArgumentError DataAPI.metadata(1, 1)
-    @test DataAPI.hasmetadata(1, 1) === nothing
+    @test DataAPI.hascolmetadata(1, 1) === nothing
+    @test_throws ArgumentError DataAPI.colmetadata(1, 1)
+    @test DataAPI.hascolmetadata(1) === nothing
+    @test_throws ArgumentError DataAPI.colmetadata(1)
+
+
     @test DataAPI.metadata(TestArray([1, 2])) == Dict("length" => 2)
     @test DataAPI.hasmetadata(TestArray([1, 2]))
-    @test DataAPI.metadata(TestArray([1, 2]), "col") == Dict("name" => "col")
-    @test DataAPI.hasmetadata(TestArray([1, 2]), "col") == true
+    @test DataAPI.colmetadata(TestArray([1, 2]), "x") == Dict("name" => "col")
+    @test DataAPI.hascolmetadata(TestArray([1, 2]), "x") == true
+    @test_throws ArgumentError DataAPI.colmetadata(TestArray([1, 2]), "y")
+    @test DataAPI.hascolmetadata(TestArray([1, 2]), "y") == false
+    @test DataAPI.colmetadata(TestArray([1, 2])) == Dict("x" => Dict("name" => "col"))
+    @test DataAPI.hascolmetadata(TestArray([1, 2])) == true
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,10 +13,8 @@ DataAPI.levels(x::TestArray) = reverse(DataAPI.levels(x.x))
 DataAPI.metadata(x::TestArray) = Dict("length" => length(x))
 DataAPI.colmetadata(x::TestArray, col) =
     col === "x" ? Dict("name" => col) : throw(ArgumentError("no metadata"))
-DataAPI.colmetadata(x::TestArray) = Dict("x" => DataAPI.colmetadata(x, "x"))
 
 DataAPI.hasmetadata(x::TestArray) = true
-DataAPI.hascolmetadata(x::TestArray) = true
 DataAPI.hascolmetadata(x::TestArray, col) = col === "x" ? true : nothing
 
 @testset "DataAPI" begin
@@ -197,8 +195,6 @@ end
     @test DataAPI.colmetadata(TestArray([1, 2]), "x") == Dict("name" => "x")
     @test DataAPI.hascolmetadata(TestArray([1, 2]), "y") === nothing
     @test_throws ArgumentError DataAPI.colmetadata(TestArray([1, 2]), "y")
-    @test DataAPI.hascolmetadata(TestArray([1, 2])) === true
-    @test DataAPI.colmetadata(TestArray([1, 2])) == Dict("x" => Dict("name" => "x"))
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ Base.size(x::TestArray) = size(x.x)
 Base.getindex(x::TestArray, i) = x.x[i]
 DataAPI.levels(x::TestArray) = reverse(DataAPI.levels(x.x))
 DataAPI.metadata(x::TestArray) = Dict("length" => length(x))
+DataAPI.metadata(x::TestArray, col) = Dict("name" => col)
+DataAPI.hasmetadata(x::TestArray) = true
+DataAPI.hasmetadata(x::TestArray, col) = true
 
 @testset "DataAPI" begin
 
@@ -175,8 +178,12 @@ end
 end
 
 @testset "metadata" begin
-    @test DataAPI.metadata(1) === nothing
+    @test_throws ArgumentError DataAPI.metadata(1)
+    @test DataAPI.hasmetadata(1) === nothing
     @test DataAPI.metadata(TestArray([1, 2])) == Dict("length" => 2)
+    @test DataAPI.hasmetadata(TestArray([1, 2]))
+    @test DataAPI.metadata(TestArray([1, 2]), "col") == Dict("name" => "col")
+    @test DataAPI.hasmetadata(TestArray([1, 2]), "col") == true
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ function DataAPI.metadata!(x::TestMeta, key::AbstractString, value; style)
 end
 
 DataAPI.deletemetadata!(x::TestMeta, key::AbstractString) = delete!(x.table, key)
-DataAPI.deletemetadata!(x::TestMeta) = empty!(x.table, key)
+DataAPI.deletemetadata!(x::TestMeta) = empty!(x.table)
 
 function DataAPI.colmetadata(x::TestMeta, col::Symbol, key::AbstractString; style::Bool=false)
     return style ? x.col[col][key] : x.col[col][key][1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ DataAPI.levels(x::TestArray) = reverse(DataAPI.levels(x.x))
 DataAPI.metadata(x::TestArray) = Dict("length" => length(x))
 DataAPI.colmetadata(x::TestArray, col) =
     col === "x" ? Dict("name" => col) : throw(ArgumentError("no metadata"))
-DataAPI.colmetadata(x::TestArray) = Dict("x" => Dict("name" => col))
+DataAPI.colmetadata(x::TestArray) = Dict("x" => DataAPI.colmetadata(x, "x"))
 
 DataAPI.hasmetadata(x::TestArray) = true
 DataAPI.hascolmetadata(x::TestArray) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,7 +175,7 @@ end
 end
 
 @testset "metadata" begin
-    @test isnothing(DataAPI.metadata(1))
+    @test DataAPI.metadata(1) === nothing
     @test DataAPI.metadata(TestArray([1, 2])) == Dict("length" => 2)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ DataAPI.levels(x::TestArray) = reverse(DataAPI.levels(x.x))
 
 DataAPI.metadata(x::TestArray) = Dict("length" => length(x))
 DataAPI.colmetadata(x::TestArray, col) =
-    col === "x" ? Dict("name" => col) : throw ArgumentError("no metadata")
+    col === "x" ? Dict("name" => col) : throw(ArgumentError("no metadata"))
 DataAPI.colmetadata(x::TestArray) = Dict("x" => Dict("name" => col))
 
 DataAPI.hasmetadata(x::TestArray) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,8 @@ end
     @test_throws ArgumentError DataAPI.colmetadata!(1, :col, "a", 10, style=:none)
     @test_throws ArgumentError DataAPI.deletecolmetadata!(1, :col, "a")
     @test_throws ArgumentError DataAPI.deletecolmetadata!(1, :col)
+    @test_throws ArgumentError DataAPI.deletecolmetadata!(1, 1, "a")
+    @test_throws ArgumentError DataAPI.deletecolmetadata!(1, 1)
     @test_throws ArgumentError DataAPI.deletecolmetadata!(1)
     @test_throws ArgumentError DataAPI.colmetadata(1, :col, "a")
     @test_throws ArgumentError DataAPI.colmetadata(1, :col, "a", style=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,7 @@ end
 
 function DataAPI.colmetadatakeys(x::TestMeta)
     isempty(x.col) && return ()
-    return Any[col => keys(x.col[col]) for col in keys(x.col)]
+    return (col => keys(x.col[col]) for col in keys(x.col))
 end
 
 function DataAPI.colmetadata!(x::TestMeta, col, key, value; style)


### PR DESCRIPTION
Following the discussion in https://github.com/JuliaData/DataFrames.jl/issues/2961 I propose to have `getmetadata` be a function defined on DataAPI.jl level. In this way in particular:
* Arrow.jl take any table and if it supports `getmetadata` write appropriate metadata to arrow file;
* DataFrames.jl `DataFrame` constructor taking a table can check if it supports metadata and if it does automatically attach this metadata to a `DataFrame`;