### PR TITLE
Implement `hasmetadata(x)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataAPI"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.11.0"
+version = "1.12.0"
 
 [compat]
 julia = "1"

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -313,10 +313,19 @@ If `style=true` return a tuple of metadata value and metadata style. Metadata
 style is an additional information about the kind of metadata that is stored
 for the `key`.
 
+Types overloading `metadata` must also overload [`hasmetadata`](@ref).
+
 $STYLE_INFO
 """
 metadata(::T, ::AbstractString; style::Bool=false) where {T} =
     throw(ArgumentError("Objects of type $T do not support getting metadata"))
+
+"""
+    hasmetadata(x)
+
+Returns `true` if metadata is associated with `x`.
+"""
+hasmetadata(x) = false
 
 """
     metadatakeys(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,8 @@ struct TestMeta
     TestMeta() = new(Dict{String, Any}(), Dict{Symbol, Dict{String, Any}}())
 end
 
+DataAPI.hasmetadata(::TestMeta) = true
+
 function DataAPI.metadata(x::TestMeta, key::AbstractString; style::Bool=false)
     return style ? x.table[key] : x.table[key][1]
 end
@@ -253,6 +255,9 @@ end
     @test_throws ArgumentError DataAPI.metadata(1, "a")
     @test_throws ArgumentError DataAPI.metadata(1, "a", style=true)
     @test DataAPI.metadatakeys(1) == ()
+
+    @test DataAPI.hasmetadata(TestMeta())
+    @test !DataAPI.hasmetadata(1)
 
     @test_throws ArgumentError DataAPI.colmetadata!(1, :col, "a", 10, style=:default)
     @test_throws ArgumentError DataAPI.deletecolmetadata!(1, :col, "a")


### PR DESCRIPTION
Simple method for checking if an object has metadata attached.