### PR TITLE
make it easier to work with metadata by providing more default behaviors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ julia = "1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames"]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,4 +12,4 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test, DataFrames"]
+test = ["DataFrames", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ julia = "1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "Test"]
+test = ["DataFrames"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,8 @@ version = "1.13.0"
 
 [compat]
 julia = "1"
-DataFrames = "1.4"
 
 [extras]
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataAPI"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.12.0"
+version = "1.13.0"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "1.13.0"
 
 [compat]
 julia = "1"
+DataFrames = "1.4"
 
 [extras]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test, DataFrames"]

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -429,7 +429,11 @@ function colmetadata end
 """
     colmetadata(x, [col]; style::Bool=false)
 
-Return a dictionary mapping all column metadata keys to metadata values
+If `col` is not passed return a dictionary mapping columns represented as
+`Symbol` that have associated metadata to dictionaries mapping all
+metadata keys to metadata values associated with table `x` for a given column.
+
+If `col` is passed a dictionary mapping all column metadata keys to metadata values
 associated with column `col` of table `x`. Throw an error if `x` does not
 support reading metadata for column `col` or column `col` is not present in `x`.
 
@@ -438,10 +442,6 @@ style is an additional information about the kind of metadata that is stored for
 the `key`.
 
 $STYLE_INFO
-
-If `col` is not passed return a dictionary mapping columns represented as
-`Symbol` that have associated metadata to dictionaries mapping all
-metadata keys to metadata values associated with table `x` for a given column.
 
 The returned dictionary may be freshly allocated on each call to `colmetadata`
 and is considered to be owned by `x` so it must not be modified.

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -359,7 +359,7 @@ the `key`.
 $STYLE_INFO
 
 The returned dictionary may be freshly allocated on each call to `metadata` and
-is considered to be owned by `x` so it should be only used for reading data.
+is considered to be owned by `x` so it must not be modified.
 """
 function metadata(x::T; style::Bool=false) where {T}
     if !metadatasupport(T).read
@@ -440,12 +440,11 @@ the `key`.
 $STYLE_INFO
 
 If `col` is not passed return a dictionary mapping columns represented as
-`Symbol` that have associated metadata to dictionaries dictionary mapping all
+`Symbol` that have associated metadata to dictionaries mapping all
 metadata keys to metadata values associated with table `x` for a given column.
 
 The returned dictionary may be freshly allocated on each call to `colmetadata`
-and is considered to be owned by `x` so it should be only used for reading
-data.
+and is considered to be owned by `x` so it must not be modified.
 """
 function colmetadata(x::T, col; style::Bool=false) where {T}
     if !colmetadatasupport(T).read

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -330,7 +330,7 @@ The `write` field indicates whether modifying metadata with the [`colmetadata!`]
 colmetadatasupport(::Type) = (read=false, write=false)
 
 """
-    metadata(x, key::AbstractString, [default]; style::Bool=false)
+    metadata(x, [key::AbstractString], [default]; style::Bool=false)
 
 Return metadata value associated with object `x` for key `key`. Throw an error
 if `x` does not support reading metadata or does not have a mapping for `key`.
@@ -343,6 +343,9 @@ $STYLE_INFO
 
 If `default` is passed then return it if reading metadata is supported but
 mapping for `key` is missing. If `style=true` return `(default, :default)`.
+
+If `key` is not passed return a dictionary mapping all metadata keys to
+metadata values associated with object `x`.
 """
 function metadata end
 
@@ -356,10 +359,10 @@ Throw an error if `x` does not support reading metadata.
 function metadatakeys end
 
 """
-    metadata!(x, key::AbstractString, value; style)
+    metadata!(x, key::AbstractString, value; style::Symbol=:default)
 
 Set metadata for object `x` for key `key` to have value `value`
-and style `style` and return `x`.
+and style `style` (`:default` by default) and return `x`.
 Throw an error if `x` does not support setting metadata.
 
 $STYLE_INFO
@@ -384,7 +387,7 @@ Throw an error if `x` does not support metadata deletion.
 function emptymetadata! end
 
 """
-    colmetadata(x, col, key::AbstractString, [default]; style::Bool=false)
+    colmetadata(x, [col], [key::AbstractString], [default]; style::Bool=false)
 
 Return metadata value associated with table `x` for column `col` and key `key`.
 Throw an error if `x` does not support reading metadata for column `col` or `x`
@@ -401,6 +404,13 @@ $STYLE_INFO
 If `default` is passed then return it if `x` supports reading metadata and has
 column `col` but mapping for `key` is missing.
 If `style=true` return `(default, :default)`.
+
+If `key` is not passed return a dictionary mapping all metadata keys to
+metadata values associated with table `x` for column `col`.
+
+If `col` is not passed return a dictionary mapping columns represented as
+`Symbol` that have associated metadata to dictionaries dictionary mapping all
+metadata keys to metadata values associated with table `x` for a given column.
 """
 function colmetadata end
 
@@ -421,10 +431,10 @@ If `x` does not support column metadata return `()`.
 function colmetadatakeys end
 
 """
-    colmetadata!(x, col, key::AbstractString, value; style)
+    colmetadata!(x, col, key::AbstractString, value; style::Symbol=:default)
 
 Set metadata for table `x` for column `col` for key `key` to have value `value`
-and style `style` and return `x`.
+and style `style` (`:default` by default) and return `x`.
 Throw an error if `x` does not support setting metadata for column `col`.
 
 $COL_INFO

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -433,7 +433,7 @@ If `col` is not passed return a dictionary mapping columns represented as
 `Symbol` that have associated metadata to dictionaries mapping all
 metadata keys to metadata values associated with table `x` for a given column.
 
-If `col` is passed a dictionary mapping all column metadata keys to metadata values
+If `col` is passed return a dictionary mapping all column metadata keys to metadata values
 associated with column `col` of table `x`. Throw an error if `x` does not
 support reading metadata for column `col` or column `col` is not present in `x`.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using Test, DataAPI
-import DataFrames
 
 const ≅ = isequal
 
@@ -328,41 +327,44 @@ end
     @test isempty(DataAPI.colmetadatakeys(tm))
 end
 
-@testset "fallback definitions of metadata and colmetadata" begin
-    df = DataFrames.DataFrame()
-    @test DataAPI.metadata(df) == Dict()
-    @test DataAPI.metadata(df, style=true) == Dict()
-    @test DataAPI.colmetadata(df) == Dict()
-    @test DataAPI.colmetadata(df, style=true) == Dict()
-    df.a = 1:2
-    df.b = 2:3
-    df.c = 3:4
-    @test DataAPI.metadata(df) == Dict()
-    @test DataAPI.metadata(df, style=true) == Dict()
-    @test DataAPI.colmetadata(df) == Dict()
-    @test DataAPI.colmetadata(df, style=true) == Dict()
-    DataAPI.metadata!(df, "a1", "b1", style=:default)
-    DataAPI.metadata!(df, "a2", "b2", style=:note)
-    DataAPI.colmetadata!(df, :a, "x1", "y1", style=:default)
-    DataAPI.colmetadata!(df, :a, "x2", "y2", style=:note)
-    DataAPI.colmetadata!(df, :c, "x3", "y3", style=:note)
-    @test DataAPI.metadata(df) == Dict("a1" => "b1", "a2" => "b2")
-    @test DataAPI.metadata(df, style=true) == Dict("a1" => ("b1", :default),
-                                                   "a2" => ("b2", :note))
-    @test DataAPI.colmetadata(df) == Dict(:a => Dict("x1" => "y1",
-                                                     "x2" => "y2"),
-                                          :c => Dict("x3" => "y3"))
-    @test DataAPI.colmetadata(df, style=true) == Dict(:a => Dict("x1" => ("y1", :default),
-                                                                 "x2" => ("y2", :note)),
-                                                      :c => Dict("x3" => ("y3", :note)))
-    @test DataAPI.colmetadata(df, :a) == Dict("x1" => "y1",
-                                              "x2" => "y2")
-    @test DataAPI.colmetadata(df, :a, style=true) == Dict("x1" => ("y1", :default),
-                                                          "x2" => ("y2", :note))
-    @test DataAPI.colmetadata(df, :b) == Dict()
-    @test DataAPI.colmetadata(df, :b, style=true) == Dict()
-    @test DataAPI.colmetadata(df, :c) == Dict("x3" => "y3")
-    @test DataAPI.colmetadata(df, :c, style=true) == Dict("x3" => ("y3", :note))
+if VERSION >= v"1.6"
+    import DataFrames
+    @testset "fallback definitions of metadata and colmetadata" begin
+        df = DataFrames.DataFrame()
+        @test DataAPI.metadata(df) == Dict()
+        @test DataAPI.metadata(df, style=true) == Dict()
+        @test DataAPI.colmetadata(df) == Dict()
+        @test DataAPI.colmetadata(df, style=true) == Dict()
+        df.a = 1:2
+        df.b = 2:3
+        df.c = 3:4
+        @test DataAPI.metadata(df) == Dict()
+        @test DataAPI.metadata(df, style=true) == Dict()
+        @test DataAPI.colmetadata(df) == Dict()
+        @test DataAPI.colmetadata(df, style=true) == Dict()
+        DataAPI.metadata!(df, "a1", "b1", style=:default)
+        DataAPI.metadata!(df, "a2", "b2", style=:note)
+        DataAPI.colmetadata!(df, :a, "x1", "y1", style=:default)
+        DataAPI.colmetadata!(df, :a, "x2", "y2", style=:note)
+        DataAPI.colmetadata!(df, :c, "x3", "y3", style=:note)
+        @test DataAPI.metadata(df) == Dict("a1" => "b1", "a2" => "b2")
+        @test DataAPI.metadata(df, style=true) == Dict("a1" => ("b1", :default),
+                                                       "a2" => ("b2", :note))
+        @test DataAPI.colmetadata(df) == Dict(:a => Dict("x1" => "y1",
+                                                         "x2" => "y2"),
+                                              :c => Dict("x3" => "y3"))
+        @test DataAPI.colmetadata(df, style=true) == Dict(:a => Dict("x1" => ("y1", :default),
+                                                                     "x2" => ("y2", :note)),
+                                                          :c => Dict("x3" => ("y3", :note)))
+        @test DataAPI.colmetadata(df, :a) == Dict("x1" => "y1",
+                                                  "x2" => "y2")
+        @test DataAPI.colmetadata(df, :a, style=true) == Dict("x1" => ("y1", :default),
+                                                              "x2" => ("y2", :note))
+        @test DataAPI.colmetadata(df, :b) == Dict()
+        @test DataAPI.colmetadata(df, :b, style=true) == Dict()
+        @test DataAPI.colmetadata(df, :c) == Dict("x3" => "y3")
+        @test DataAPI.colmetadata(df, :c, style=true) == Dict("x3" => ("y3", :note))
+    end
 end
 
 end # @testset "DataAPI"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test, DataAPI
+import DataFrames
 
 const ≅ = isequal
 
@@ -325,6 +326,43 @@ end
     @test DataAPI.colmetadata!(tm, :col, "a", "100", style=:note) == tm
     DataAPI.emptycolmetadata!(tm)
     @test isempty(DataAPI.colmetadatakeys(tm))
+end
+
+@testset "fallback definitions of metadata and colmetadata" begin
+    df = DataFrames.DataFrame()
+    @test DataAPI.metadata(df) == Dict()
+    @test DataAPI.metadata(df, style=true) == Dict()
+    @test DataAPI.colmetadata(df) == Dict()
+    @test DataAPI.colmetadata(df, style=true) == Dict()
+    df.a = 1:2
+    df.b = 2:3
+    df.c = 3:4
+    @test DataAPI.metadata(df) == Dict()
+    @test DataAPI.metadata(df, style=true) == Dict()
+    @test DataAPI.colmetadata(df) == Dict()
+    @test DataAPI.colmetadata(df, style=true) == Dict()
+    DataAPI.metadata!(df, "a1", "b1", style=:default)
+    DataAPI.metadata!(df, "a2", "b2", style=:note)
+    DataAPI.colmetadata!(df, :a, "x1", "y1", style=:default)
+    DataAPI.colmetadata!(df, :a, "x2", "y2", style=:note)
+    DataAPI.colmetadata!(df, :c, "x3", "y3", style=:note)
+    @test DataAPI.metadata(df) == Dict("a1" => "b1", "a2" => "b2")
+    @test DataAPI.metadata(df, style=true) == Dict("a1" => ("b1", :default),
+                                                   "a2" => ("b2", :note))
+    @test DataAPI.colmetadata(df) == Dict(:a => Dict("x1" => "y1",
+                                                     "x2" => "y2"),
+                                          :c => Dict("x3" => "y3"))
+    @test DataAPI.colmetadata(df, style=true) == Dict(:a => Dict("x1" => ("y1", :default),
+                                                                 "x2" => ("y2", :note)),
+                                                      :c => Dict("x3" => ("y3", :note)))
+    @test DataAPI.colmetadata(df, :a) == Dict("x1" => "y1",
+                                              "x2" => "y2")
+    @test DataAPI.colmetadata(df, :a, style=true) == Dict("x1" => ("y1", :default),
+                                                          "x2" => ("y2", :note))
+    @test DataAPI.colmetadata(df, :b) == Dict()
+    @test DataAPI.colmetadata(df, :b, style=true) == Dict()
+    @test DataAPI.colmetadata(df, :c) == Dict("x3" => "y3")
+    @test DataAPI.colmetadata(df, :c, style=true) == Dict("x3" => ("y3", :note))
 end
 
 end # @testset "DataAPI"


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataAPI.jl/issues/55
Fixes https://github.com/JuliaData/DataAPI.jl/issues/51

@tokazama - in relation to #51 I ended up recommending to return a dictionary (not just an iterator). Do you think it would be acceptable, or you would prefer to require only an iterator of pairs?

The benefit of dictionary would be that later it is easier for users to work with it. I assume that if a given value does not have already an underlying dictionary to store metadata (most have) then just `Dict` will be used since this is a non-lazy interface.

If someone wants a lazy iterator then using `metadatakeys` and then getting the required metadata is an option that is available.