### PR TITLE
Suppor dimensional metadata

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataAPI"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.15.0"
+version = "1.16.0"
 
 [compat]
 julia = "1"

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -622,7 +622,7 @@ function deletedimmetadata! end
 """
     emptydimmetadata!(x, dim::Int)
 
-Delete all metadata for `x` corresponding to dimension `dim` and return `x`.
+Delete all metadata for object `x` for to dimension `dim` and return `x`.
 Throw an error if `x` does not support metadata deletion for dimension `dim`.
 """
 function emptydimmetadata! end

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -602,7 +602,7 @@ function dimmetadatakeys end
 """
     dimmetadata!(x, dim::Int, key::AbstractString, value; style::Symbol=:default)
 
-Set metadata for `x` for dimension `dim` for key `key` to have value `value`
+Set metadata for object `x` for dimension `dim` for key `key` to have value `value`
 and style `style` (`:default` by default) and return `x`.
 Throw an error if `x` does not support setting metadata for dimension `dim`.
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -573,7 +573,7 @@ function dimmetadata(x::T, dim::Int; style::Bool=false) where {T}
     end
     return Dict(key => dimmetadata(x, dim, key, style=style) for key in dimmetadatakeys(x, dim))
 end
-function dimmetadata(x::T; style::Bool=false) where {T}
+function dimmetadata(x; style::Bool=false)
     Tuple(dimmetadata(x, dim; style=style) for dim in 1:ndims(x))
 end
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -623,6 +623,7 @@ function deletedimmetadata! end
     emptydimmetadata!(x, dim::Int)
 
 Delete all metadata for object `x` for to dimension `dim` and return `x`.
+If `dim` is not passed delete all dimension level metadata for table `x`.
 Throw an error if `x` does not support metadata deletion for dimension `dim`.
 """
 function emptydimmetadata! end

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -562,7 +562,7 @@ the `key`.
 
 $STYLE_INFO
 
-The returned dictionary may be freshly allocated on each call to `dimmetadata` and
+The returned object may be freshly allocated on each call to `dimmetadata` and
 is considered to be owned by `x` so it must not be modified.
 """
 function dimmetadata(x::T, dim::Int; style::Bool=false) where {T}

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -381,6 +381,9 @@ end
 Return an iterator of metadata keys for which `metadata(x, key)` returns a
 metadata value.
 Throw an error if `x` does not support reading metadata.
+
+If `metadatasupport(typeof(x)).read` or `metadatasupport(typeof(x)).write` return `true`
+this should also be defined.
 """
 function metadatakeys end
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -562,7 +562,8 @@ values associated with object `x` for a given dimension, so that
 If `dim` is passed return a dictionary mapping all column metadata keys
 to metadata values associated with dimension `dim` of object `x`, so that
 `colmetadata(x, dim)[key] == dimmetadata(x, dim, key)`.
-Throw an error if `x` does not support reading metadata corresponding to dimension `dim`.
+Throw an error if `x` does not support reading metadata for dimension `dim`
+or `dim` is not dimension of `x`.
 
 If `style=true` values are tuples of metadata value and metadata style. Metadata
 style is an additional information about the kind of metadata that is stored for

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -571,9 +571,14 @@ function dimmetadata(x::T, dim::Int; style::Bool=false) where {T}
 end
 
 """
-    dimmetadatakeys(x, dim::Int)
+    dimmetadatakeys(x, [dim::Int])
 
-Return an iterator of keys for corresponding to metadata for dimension `dim` of `x`.
+If `dim` is passed return an iterator of metadata keys for which
+`metadata(x, dim, key)` returns a metadata value. Throw an error if `x` does not
+support reading column metadata or if `dim` is not a dimension of `x`.
+
+If `dim` is not passed return an iterator of `dim => colmetadatakeys(x, dim)`
+pairs for all dimensions that have metadata.
 If `x` does not support dimension metadata return `()`.
 """
 function dimmetadatakeys end

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -554,9 +554,14 @@ function dimmetadata end
 """
     dimmetadata(x, [dim::Int]; style::Bool=false)
 
-Return a dictionary of metadata corresponding to dimension `dim` of object `x`. If `dim`
- is not passed return a collection mapping each dimension to its metadata so that
-`collection[dim][key] == dimmetadata(x, dim, key)`.
+If `dim` is not passed, return a dictionary mapping dimensions that have
+associated metadata to dictionaries mapping all metadata keys to metadata
+values associated with object `x` for a given dimension, so that
+`colmetadata(x)[dim][key] == dimmetadata(x, dim, key)`.
+
+If `dim` is passed return a dictionary mapping all column metadata keys
+to metadata values associated with dimension `dim` of object `x`, so that
+`colmetadata(x, dim)[key] == dimmetadata(x, dim, key)`.
 Throw an error if `x` does not support reading metadata corresponding to dimension `dim`.
 
 If `style=true` values are tuples of metadata value and metadata style. Metadata

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -480,6 +480,7 @@ Following the Tables.jl contract `Symbol` and `Int` are always allowed.
 
 If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
 pairs for all columns that have metadata, where `col` are `Symbol`.
+If `x` does not support column metadata return `()`.
 
 If `colmetadatasupport(typeof(x)).read` or `colmetadatasupport(typeof(x)).write` return `true`
 this should also be defined.

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -323,20 +323,6 @@ The `write` field indicates whether modifying metadata with the [`metadata!`](@r
 metadatasupport(::Type) = (read=false, write=false)
 
 """
-    colmetadatasupport(T::Type)
-
-Return a `NamedTuple{(:read, :write), Tuple{Bool, Bool}}` indicating whether
-values of type `T` support column metadata.
-
-The `read` field indicates whether reading metadata with the [`colmetadata`](@ref)
-and [`colmetadatakeys`](@ref) functions is supported.
-
-The `write` field indicates whether modifying metadata with the [`colmetadata!`](@ref),
-[`deletecolmetadata!`](@ref), and [`emptycolmetadata!`](@ref) functions is supported.
-"""
-colmetadatasupport(::Type) = (read=false, write=false)
-
-"""
     metadata(x, key::AbstractString, [default]; style::Bool=false)
 
 Return metadata value associated with object `x` for key `key`. Throw an error
@@ -416,6 +402,20 @@ Throw an error if `x` does not support metadata deletion.
 function emptymetadata! end
 
 """
+    colmetadatasupport(T::Type)
+
+Return a `NamedTuple{(:read, :write), Tuple{Bool, Bool}}` indicating whether
+values of type `T` support column metadata.
+
+The `read` field indicates whether reading metadata with the [`colmetadata`](@ref)
+and [`colmetadatakeys`](@ref) functions is supported.
+
+The `write` field indicates whether modifying metadata with the [`colmetadata!`](@ref),
+[`deletecolmetadata!`](@ref), and [`emptycolmetadata!`](@ref) functions is supported.
+"""
+colmetadatasupport(::Type) = (read=false, write=false)
+
+"""
     colmetadata(x, col, key::AbstractString, [default]; style::Bool=false)
 
 Return metadata value associated with table `x` for column `col` and key `key`.
@@ -485,8 +485,8 @@ If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
 pairs for all columns that have metadata, where `col` are `Symbol`.
 If `x` does not support column metadata return `()`.
 
-This method must be defined if `dimmetadatasupport(typeof(x)).read` or
-`dimmetadatasupport(typeof(x)).write` return `true`.
+This method must be defined if `colmetadatasupport(typeof(x)).read` or
+`colmetadatasupport(typeof(x)).write` return `true`.
 """
 function colmetadatakeys end
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -516,6 +516,97 @@ Throw an error if `x` does not support metadata deletion for column `col`.
 function emptycolmetadata! end
 
 """
+    dimmetadatasupport(T::Type, dim::Int)
+
+Return a `NamedTuple{(:read, :write), Tuple{Bool, Bool}}` indicating whether
+values of type `T` support metadata correspond to dimension `dim`.
+
+The `read` field indicates whether reading metadata with the [`dimmetadata`](@ref)
+and [`dimmetadatakeys`]](@ref) functions is supported.
+
+The `write` field indicates whether modifying metadata with the [`dimmetadata!`](@ref),
+[`deletemetadata!`](@ref), and [`emptymetadata!`](@ref) functions is supported.
+"""
+dimmetadatasupport(::Type, i::Int) = (read=false, write=false)
+
+"""
+    dimmetadata(x, dim::Int, key::AbstractString, [default]; style::Bool=false)
+
+Return metadata value associated with `x` at dimension `dim` and key `key`.
+Throw an error if `x` does not support reading metadata for dimension `dim` or `x`
+supports reading metadata, but does not have a mapping for dimension `dim` for `key`.
+
+If `style=true` return a tuple of metadata value and metadata style. Metadata
+style is an additional information about the kind of metadata that is stored for
+the `key`.
+
+$STYLE_INFO
+
+If `default` is passed then return it if `x` supports reading metadata and has
+dimension `dim` but mapping for `key` is missing.
+If `style=true` return `(default, :default)`.
+"""
+function dimmetadata end
+
+"""
+    dimmetadata(x, dim::Int; style::Bool=false)
+
+Return a dictionary of metadata corresponding to dimension `dim` of object `x`.
+Throw an error if `x` does not support reading metadata corresponding to dimension `dim`.
+
+If `style=true` values are tuples of metadata value and metadata style. Metadata
+style is an additional information about the kind of metadata that is stored for
+the `key`.
+
+$STYLE_INFO
+
+The returned dictionary may be freshly allocated on each call to `metadata` and
+is considered to be owned by `x` so it must not be modified.
+"""
+function dimmetadata(x::T, dim::Int; style::Bool=false) where {T}
+    if !dimmetadatasupport(T, dim).read
+        throw(ArgumentError("Objects of type $T do not support reading dimension metadata"))
+    end
+    return Dict(key => dimmetadata(x, dim, key, style=style) for key in dimmetadatakeys(x, dim))
+end
+
+"""
+    dimmetadatakeys(x, dim::Int)
+
+Return an iterator of keys for corresponding to metadata for dimension `dim` of `x`.
+If `x` does not support dimension metadata return `()`.
+"""
+function dimmetadatakeys end
+
+"""
+    dimmetadata!(x, dim::Int, key::AbstractString, value; style::Symbol=:default)
+
+Set the metadata value and style associated with `x` at dimension `dim` for key `key` to `value`
+and `style`, respectively. (`:default` by default) and return `x`.
+Throw an error if `x` does not support setting metadata for dimension `dim`.
+
+$STYLE_INFO
+"""
+function dimmetadata! end
+
+"""
+    deletedimmetadata!(x, dim::Int, key::AbstractString)
+
+Delete metadata for corresponding to dimension `dim` and key `key` of `x` and return `x`
+(if metadata for `key` is not present do not perform any action).
+Throw an error if `x` does not support metadata deletion for dimension `dim`.
+"""
+function deletedimmetadata! end
+
+"""
+    emptydimmetadata!(x, dim::Int)
+
+Delete all metadata for `x` corresponding to dimension `dim` and return `x`.
+Throw an error if `x` does not support metadata deletion for dimension `dim`.
+"""
+function emptydimmetadata! end
+
+"""
     rownumber(row)
 
 Return the row number of `row` in the source table.

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -532,7 +532,7 @@ dimmetadatasupport(::Type, i::Int) = (read=false, write=false)
 """
     dimmetadata(x, dim::Int, key::AbstractString, [default]; style::Bool=false)
 
-Return metadata value associated with `x` at dimension `dim` and key `key`.
+Return metadata value associated with `x` for dimension `dim` and key `key`.
 Throw an error if `x` does not support reading metadata for dimension `dim` or `x`
 supports reading metadata, but does not have a mapping for dimension `dim` for `key`.
 
@@ -581,8 +581,8 @@ function dimmetadatakeys end
 """
     dimmetadata!(x, dim::Int, key::AbstractString, value; style::Symbol=:default)
 
-Set the metadata value and style associated with `x` at dimension `dim` for key `key` to `value`
-and `style`, respectively. (`:default` by default) and return `x`.
+Set metadata for `x` for dimension `dim` for key `key` to have value `value`
+and style `style` (`:default` by default) and return `x`.
 Throw an error if `x` does not support setting metadata for dimension `dim`.
 
 $STYLE_INFO

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -535,7 +535,7 @@ dimmetadatasupport(::Type, i::Int) = (read=false, write=false)
 """
     dimmetadata(x, dim::Int, key::AbstractString, [default]; style::Bool=false)
 
-Return metadata value associated with `x` for dimension `dim` and key `key`.
+Return metadata value associated with object `x` for dimension `dim` and key `key`.
 Throw an error if `x` does not support reading metadata for dimension `dim` or `x`
 supports reading metadata, but does not have a mapping for dimension `dim` for `key`.
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -482,8 +482,8 @@ If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
 pairs for all columns that have metadata, where `col` are `Symbol`.
 If `x` does not support column metadata return `()`.
 
-If `colmetadatasupport(typeof(x)).read` or `colmetadatasupport(typeof(x)).write` return `true`
-this should also be defined.
+This method must be defined if `dimmetadatasupport(typeof(x)).read` or
+`dimmetadatasupport(typeof(x)).write` return `true`.
 """
 function colmetadatakeys end
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -608,7 +608,7 @@ function dimmetadata! end
 """
     deletedimmetadata!(x, dim::Int, key::AbstractString)
 
-Delete metadata for corresponding to dimension `dim` and key `key` of `x` and return `x`
+Delete metadata corresponding to dimension `dim` of `x` for key `key` and return `x`
 (if metadata for `key` is not present do not perform any action).
 Throw an error if `x` does not support metadata deletion for dimension `dim`.
 """

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -613,7 +613,7 @@ function dimmetadata! end
 """
     deletedimmetadata!(x, dim::Int, key::AbstractString)
 
-Delete metadata corresponding to dimension `dim` of `x` for key `key` and return `x`
+Delete metadata for object `x` for dimension `dim` for key `key` and return `x`
 (if metadata for `key` is not present do not perform any action).
 Throw an error if `x` does not support metadata deletion for dimension `dim`.
 """

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -472,7 +472,7 @@ end
     colmetadatakeys(x, [col])
 
 If `col` is passed return an iterator of metadata keys for which
-`metadata(x, col, key)` returns a metadata value. Throw an error if `x` does not
+`colmetadata(x, col, key)` returns a metadata value. Throw an error if `x` does not
 support reading column metadata or if `col` is not a column of `x`.
 
 `col` must have a type that is supported by table `x` for column indexing.
@@ -574,10 +574,10 @@ end
     dimmetadatakeys(x, [dim::Int])
 
 If `dim` is passed return an iterator of metadata keys for which
-`metadata(x, dim, key)` returns a metadata value. Throw an error if `x` does not
-support reading column metadata or if `dim` is not a dimension of `x`.
+`dimmetadata(x, dim, key)` returns a metadata value. Throw an error if `x` does not
+support reading dimension metadata or if `dim` is not a dimension of `x`.
 
-If `dim` is not passed return an iterator of `dim => colmetadatakeys(x, dim)`
+If `dim` is not passed return an iterator of `dim => dimmetadatakeys(x, dim)`
 pairs for all dimensions that have metadata.
 If `x` does not support dimension metadata return `()`.
 """

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -594,8 +594,8 @@ support reading dimension metadata or if `dim` is not a dimension of `x`.
 If `dim` is not passed return an iterator of `dim => dimmetadatakeys(x, dim)`
 pairs for all dimensions that have metadata.
 
-If `dimmetadatasupport(typeof(x)).read` or `dimmetadatasupport(typeof(x)).write` return `true`
-this should also be defined.
+This method must be defined if `dimmetadatasupport(typeof(x)).read` or
+`dimmetadatasupport(typeof(x)).write` return `true`.
 """
 function dimmetadatakeys end
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -551,7 +551,7 @@ If `style=true` return `(default, :default)`.
 function dimmetadata end
 
 """
-    dimmetadata(x, dim::Int; style::Bool=false)
+    dimmetadata(x, [dim::Int]; style::Bool=false)
 
 Return a dictionary of metadata corresponding to dimension `dim` of object `x`. If `dim`
  is not passed return a collection mapping each dimension to its metadata so that

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -480,7 +480,9 @@ Following the Tables.jl contract `Symbol` and `Int` are always allowed.
 
 If `col` is not passed return an iterator of `col => colmetadatakeys(x, col)`
 pairs for all columns that have metadata, where `col` are `Symbol`.
-If `x` does not support column metadata return `()`.
+
+If `colmetadatasupport(typeof(x)).read` or `colmetadatasupport(typeof(x)).write` return `true`
+this should also be defined.
 """
 function colmetadatakeys end
 
@@ -584,15 +586,11 @@ support reading dimension metadata or if `dim` is not a dimension of `x`.
 
 If `dim` is not passed return an iterator of `dim => dimmetadatakeys(x, dim)`
 pairs for all dimensions that have metadata.
-If `x` does not support dimension metadata return `()`.
+
+If `dimmetadatasupport(typeof(x)).read` or `dimmetadatasupport(typeof(x)).write` return `true`
+this should also be defined.
 """
-function dimmetadatakeys(x, dim::Int)
-    dimmetadatasupport(typeof(x), dim).read || return ()
-    throw(MethodError(dimmetadatakeys, (x, dim)))
-end
-function dimmetadatakeys(x)
-    Dict(dim => dimmetadatakeys(x, dim) for dim in 1:ndims(x))
-end
+function dimmetadatakeys end
 
 """
     dimmetadata!(x, dim::Int, key::AbstractString, value; style::Symbol=:default)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -343,15 +343,14 @@ end
     @test_throws MethodError DataAPI.colmetadatakeys(1, 1)
     @test_throws MethodError DataAPI.colmetadatakeys(1)
 
-    dim = 1
-    @test_throws MethodError DataAPI.dimmetadata!(1, dim, "a", 10, style=:default)
-    @test_throws MethodError DataAPI.deletedimmetadata!(1, dim, "a")
-    @test_throws MethodError DataAPI.emptydimmetadata!(1, dim)
-    @test_throws MethodError DataAPI.dimmetadata(1, dim, "a")
-    @test_throws ArgumentError DataAPI.dimmetadata(1, dim)
-    @test_throws MethodError DataAPI.dimmetadata(1, dim, "a", style=true)
-    @test_throws ArgumentError DataAPI.dimmetadata(1, dim, style=true)
-    @test_throws MethodError DataAPI.dimmetadatakeys(1, dim)
+    @test_throws MethodError DataAPI.dimmetadata!(1, 1, "a", 10, style=:default)
+    @test_throws MethodError DataAPI.deletedimmetadata!(1, 1, "a")
+    @test_throws MethodError DataAPI.emptydimmetadata!(1, 1)
+    @test_throws MethodError DataAPI.dimmetadata(1, 1, "a")
+    @test_throws ArgumentError DataAPI.dimmetadata(1, 1)
+    @test_throws MethodError DataAPI.dimmetadata(1, 1, "a", style=true)
+    @test_throws ArgumentError DataAPI.dimmetadata(1, 1, style=true)
+    @test_throws MethodError DataAPI.dimmetadatakeys(1, 1)
 
     @test DataAPI.metadatasupport(Int) == (read=false, write=false)
     @test DataAPI.colmetadatasupport(Int) == (read=false, write=false)
@@ -409,24 +408,24 @@ end
     DataAPI.emptycolmetadata!(tm)
     @test isempty(DataAPI.colmetadatakeys(tm))
 
-    @test isempty(DataAPI.dimmetadatakeys(tm, dim))
-    @test DataAPI.dimmetadata(tm, dim) == Dict()
-    @test DataAPI.dimmetadata(tm, dim, style=true) == Dict()
-    @test DataAPI.dimmetadata!(tm, dim, "a", "100", style=:note) == tm
-    @test collect(DataAPI.dimmetadatakeys(tm, dim)) == ["a"]
-    @test_throws KeyError DataAPI.dimmetadata(tm, dim, "b")
-    @test DataAPI.dimmetadata(tm, dim, "b", 123) == 123
-    @test_throws KeyError DataAPI.dimmetadata(tm, dim, "b", style=true)
-    @test DataAPI.dimmetadata(tm, dim, "b", 123, style=true) == (123, :default)
-    @test DataAPI.dimmetadata(tm, dim, "a") == "100"
-    @test DataAPI.dimmetadata(tm, dim) == Dict("a" => "100")
-    @test DataAPI.dimmetadata(tm, dim, "a", style=true) == ("100", :note)
-    @test DataAPI.dimmetadata(tm, dim, style=true) == Dict("a" => ("100", :note))
-    DataAPI.deletedimmetadata!(tm, dim, "a")
-    @test isempty(DataAPI.dimmetadatakeys(tm, dim))
-    @test DataAPI.dimmetadata!(tm, dim, "a", "100", style=:note) == tm
-    DataAPI.emptydimmetadata!(tm, dim)
-    @test isempty(DataAPI.dimmetadatakeys(tm, dim))
+    @test isempty(DataAPI.dimmetadatakeys(tm, 1))
+    @test DataAPI.dimmetadata(tm, 1) == Dict()
+    @test DataAPI.dimmetadata(tm, 1, style=true) == Dict()
+    @test DataAPI.dimmetadata!(tm, 1, "a", "100", style=:note) == tm
+    @test collect(DataAPI.dimmetadatakeys(tm, 1)) == ["a"]
+    @test_throws KeyError DataAPI.dimmetadata(tm, 1, "b")
+    @test DataAPI.dimmetadata(tm, 1, "b", 123) == 123
+    @test_throws KeyError DataAPI.dimmetadata(tm, 1, "b", style=true)
+    @test DataAPI.dimmetadata(tm, 1, "b", 123, style=true) == (123, :default)
+    @test DataAPI.dimmetadata(tm, 1, "a") == "100"
+    @test DataAPI.dimmetadata(tm, 1) == Dict("a" => "100")
+    @test DataAPI.dimmetadata(tm, 1, "a", style=true) == ("100", :note)
+    @test DataAPI.dimmetadata(tm, 1, style=true) == Dict("a" => ("100", :note))
+    DataAPI.deletedimmetadata!(tm, 1, "a")
+    @test isempty(DataAPI.dimmetadatakeys(tm, 1))
+    @test DataAPI.dimmetadata!(tm, 1, "a", "100", style=:note) == tm
+    DataAPI.emptydimmetadata!(tm, 1)
+    @test isempty(DataAPI.dimmetadatakeys(tm, 1))
 end
 
 @testset "rownumber" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ struct TestMeta
         new(Dict{String, Any}(), Dict{Symbol, Dict{String, Any}}(), (Dict{String, Any}(), Dict{String, Any}()))
     end
 end
+Base.ndims(::TestMeta) = 2
 
 DataAPI.metadatasupport(::Type{TestMeta}) = (read=true, write=true)
 DataAPI.colmetadatasupport(::Type{TestMeta}) = (read=true, write=true)
@@ -350,7 +351,6 @@ end
     @test_throws ArgumentError DataAPI.dimmetadata(1, 1)
     @test_throws MethodError DataAPI.dimmetadata(1, 1, "a", style=true)
     @test_throws ArgumentError DataAPI.dimmetadata(1, 1, style=true)
-    @test_throws MethodError DataAPI.dimmetadatakeys(1, 1)
 
     @test DataAPI.metadatasupport(Int) == (read=false, write=false)
     @test DataAPI.colmetadatasupport(Int) == (read=false, write=false)
@@ -409,7 +409,9 @@ end
     @test isempty(DataAPI.colmetadatakeys(tm))
 
     @test isempty(DataAPI.dimmetadatakeys(tm, 1))
+    @test isempty(DataAPI.dimmetadatakeys(tm)[1])
     @test DataAPI.dimmetadata(tm, 1) == Dict()
+    @test DataAPI.dimmetadata(tm) == (Dict(), Dict())
     @test DataAPI.dimmetadata(tm, 1, style=true) == Dict()
     @test DataAPI.dimmetadata!(tm, 1, "a", "100", style=:note) == tm
     @test collect(DataAPI.dimmetadatakeys(tm, 1)) == ["a"]
@@ -419,6 +421,7 @@ end
     @test DataAPI.dimmetadata(tm, 1, "b", 123, style=true) == (123, :default)
     @test DataAPI.dimmetadata(tm, 1, "a") == "100"
     @test DataAPI.dimmetadata(tm, 1) == Dict("a" => "100")
+    @test DataAPI.dimmetadata(tm)[1] == Dict("a" => "100")
     @test DataAPI.dimmetadata(tm, 1, "a", style=true) == ("100", :note)
     @test DataAPI.dimmetadata(tm, 1, style=true) == Dict("a" => ("100", :note))
     DataAPI.deletedimmetadata!(tm, 1, "a")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,7 @@ function DataAPI.deletedimmetadata!(x::TestMeta, dim::Int, key::AbstractString)
     delete!(x.dims[dim], key)
     return x
 end
+
 function DataAPI.emptydimmetadata!(x::TestMeta, dim::Int)
     empty!(x.dims[dim])
     return x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ end
 DataAPI.metadatasupport(::Type{TestMeta}) = (read=true, write=true)
 DataAPI.colmetadatasupport(::Type{TestMeta}) = (read=true, write=true)
 function DataAPI.dimmetadatasupport(::Type{TestMeta}, dim::Int)
-    if dim === 1 || dim === 2
+    if dim == 1 || dim == 2
         (read=true, write=true)
     else
         (read=false, write=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -409,7 +409,6 @@ end
     DataAPI.emptycolmetadata!(tm)
     @test isempty(DataAPI.colmetadatakeys(tm))
 
-    dim = 1
     @test isempty(DataAPI.dimmetadatakeys(tm, dim))
     @test DataAPI.dimmetadata(tm, dim) == Dict()
     @test DataAPI.dimmetadata(tm, dim, style=true) == Dict()


### PR DESCRIPTION
The core metadata methods (`metadata`, `metadata!`, etc.) provide an intuitive method of communicating that a key-value pair provides some information about the instance of the object it is attached to. The column metadata methods similarly provide an intuitive method of communicating the a key-value pair provides some information about the column of a particular object. However, data with multiple dimensions (array, mesh, coordinates, etc.) often have metadata stored per dimension.

This PR provides support for metadata corresponding to specific dimensions. New method implemented here follow the name pattern of column metadata methods (`colmetadata` to `dimmetadata`).