### PR TITLE
add a `groupby` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataAPI"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.15.0"
+version = "1.16.0"
 
 [compat]
 julia = "1"

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -528,8 +528,6 @@ function rownumber end
 Group `obj` into partitions specified by `args` and `kw`,
 which may vary according to the implementation for `obj`.
 
-The return value an iterable over the groups.
-
 To avoid type piracy and method ambiguities, implementations of `groupby` 
 must restrict the first argument to a type defined in the same package. 
 """

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -522,4 +522,14 @@ Return the row number of `row` in the source table.
 """
 function rownumber end
 
+"""
+    groupby(obj, args...; kw...)
+
+Group `obj` into partitions specified by `args` and `kw`,
+which may vary according to the implementation for `obj`.
+
+The return value an iterable over the groups.
+"""
+function groupby end
+
 end # module

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -529,6 +529,9 @@ Group `obj` into partitions specified by `args` and `kw`,
 which may vary according to the implementation for `obj`.
 
 The return value an iterable over the groups.
+
+To avoid type piracy and method ambiguities, implementations of `groupby` 
+must restrict the first argument to a type defined in the same package. 
 """
 function groupby end
 

--- a/src/DataAPI.jl
+++ b/src/DataAPI.jl
@@ -522,15 +522,8 @@ Return the row number of `row` in the source table.
 """
 function rownumber end
 
-"""
-    groupby(obj, args...; kw...)
-
-Group `obj` into partitions specified by `args` and `kw`,
-which may vary according to the implementation for `obj`.
-
-To avoid type piracy and method ambiguities, implementations of `groupby` 
-must restrict the first argument to a type defined in the same package. 
-"""
+# To avoid type piracy and method ambiguities, implementations of `groupby` 
+# must restrict the first argument to a type defined in the same package. 
 function groupby end
 
 end # module


### PR DESCRIPTION
Add a `groupby` method to DataAPI so it can be shared accross packages like DataFrames.jl and DimensionalData.jl.

See: https://github.com/rafaqz/DimensionalData.jl/pull/591